### PR TITLE
Move discipline lock from T3 to T4

### DIFF
--- a/Content.Shared/Research/Prototypes/TechDisciplinePrototype.cs
+++ b/Content.Shared/Research/Prototypes/TechDisciplinePrototype.cs
@@ -44,5 +44,5 @@ public sealed partial class TechDisciplinePrototype : IPrototype
     /// Purchasing this tier of technology causes a server to become "locked" to this discipline.
     /// </summary>
     [DataField("lockoutTier")]
-    public int LockoutTier = 3;
+    public int LockoutTier = 4;
 }

--- a/Content.Shared/Research/Prototypes/TechDisciplinePrototype.cs
+++ b/Content.Shared/Research/Prototypes/TechDisciplinePrototype.cs
@@ -44,5 +44,5 @@ public sealed partial class TechDisciplinePrototype : IPrototype
     /// Purchasing this tier of technology causes a server to become "locked" to this discipline.
     /// </summary>
     [DataField("lockoutTier")]
-    public int LockoutTier = 4;
+    public int LockoutTier = 3;
 }

--- a/Resources/Prototypes/Research/disciplines.yml
+++ b/Resources/Prototypes/Research/disciplines.yml
@@ -9,6 +9,7 @@
     1: 0
     2: 0.75
     3: 0.75
+  lockoutTier: 4
 
 - type: techDiscipline
   id: Arsenal
@@ -21,6 +22,7 @@
     1: 0
     2: 0.75
     3: 0.75
+  lockoutTier: 4
 
 - type: techDiscipline
   id: Experimental
@@ -33,6 +35,7 @@
     1: 0
     2: 0.75
     3: 0.75
+  lockoutTier: 4
 
 - type: techDiscipline
   id: CivilianServices
@@ -45,3 +48,4 @@
     1: 0
     2: 0.75
     3: 0.75
+  lockoutTier: 4

--- a/Resources/Prototypes/Research/disciplines.yml
+++ b/Resources/Prototypes/Research/disciplines.yml
@@ -9,7 +9,7 @@
     1: 0
     2: 0.75
     3: 0.75
-  lockoutTier: 4
+  lockoutTier: 4 # Corvax-Next-TechLock
 
 - type: techDiscipline
   id: Arsenal
@@ -22,7 +22,7 @@
     1: 0
     2: 0.75
     3: 0.75
-  lockoutTier: 4
+  lockoutTier: 4 # Corvax-Next-TechLock
 
 - type: techDiscipline
   id: Experimental
@@ -35,7 +35,7 @@
     1: 0
     2: 0.75
     3: 0.75
-  lockoutTier: 4
+  lockoutTier: 4 # Corvax-Next-TechLock
 
 - type: techDiscipline
   id: CivilianServices
@@ -48,4 +48,4 @@
     1: 0
     2: 0.75
     3: 0.75
-  lockoutTier: 4
+  lockoutTier: 4 # Corvax-Next-TechLock


### PR DESCRIPTION
## Описание PR
Изменил цифру блокировки изучения технологий на Т4

## Почему / Баланс
Даст больше мотиваций для исследований технологий в RnD, больше возможностей для игры.

Баланс: Считаю, что влияние будет минимальным, так как при текущих реалиях онлайна и экипажа не всегда исследуется даже четверть или пятая часть всех технологий.

Ссылка на предложение в дискорд сервере: https://discord.com/channels/919301044784226385/1301821257695887411

## Технические детали
Изменение одной циферки по пути Content.Shared/Research/Prototypes/TechDisciplinePrototype.cs


## Медиа
![20241104081436_1](https://github.com/user-attachments/assets/d51d15ca-afc2-410c-b9a3-1a1fc5cdda08)


## Требования
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.


**Список изменений**
:cl:
- tweak: Теперь можно исследовать Т3 технологии всех дисциплин