### PR TITLE
brigmedic spawn roles

### DIFF
--- a/Resources/Prototypes/Corvax/Maps/astra.yml
+++ b/Resources/Prototypes/Corvax/Maps/astra.yml
@@ -48,6 +48,7 @@
             SecurityCadet: [ 3, 4 ]
             Detective: [ 1, 1 ]
             Pilot: [ 1, 1 ]
+            Brigmedic: [ 1, 1 ] # Corvax-Next-Brigmedic
             # service
             HeadOfPersonnel: [ 1, 1 ]
             Bartender: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/avrite.yml
+++ b/Resources/Prototypes/Corvax/Maps/avrite.yml
@@ -48,6 +48,7 @@
             SecurityCadet: [ 3, 4 ]
             Detective: [ 1, 1 ]
             Pilot: [ 1, 1]
+            Brigmedic: [ 1, 1 ] # Corvax-Next-Brigmedic
             # service
             HeadOfPersonnel: [ 1, 1 ]
             Bartender: [ 2, 2 ]

--- a/Resources/Prototypes/Corvax/Maps/delta.yml
+++ b/Resources/Prototypes/Corvax/Maps/delta.yml
@@ -48,6 +48,7 @@
             SecurityCadet: [ 3, 3 ]
             Detective: [ 1, 1 ]
             Pilot: [ 1, 1 ]
+            Brigmedic: [ 1, 1 ] # Corvax-Next-Brigmedic
             # service
             HeadOfPersonnel: [ 1, 1 ]
             Bartender: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/maus.yml
+++ b/Resources/Prototypes/Corvax/Maps/maus.yml
@@ -49,6 +49,7 @@
             SecurityCadet: [ 2, 2 ]
             Detective: [ 1, 1 ]
             Pilot: [ 1, 1 ]
+            Brigmedic: [ 1, 1 ] # Corvax-Next-Brigmedic
             # service
             HeadOfPersonnel: [ 1, 1 ]
             Bartender: [ 1, 1 ]
@@ -67,4 +68,3 @@
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 1, 1 ]
-            

--- a/Resources/Prototypes/Corvax/Maps/paper.yml
+++ b/Resources/Prototypes/Corvax/Maps/paper.yml
@@ -48,6 +48,7 @@
             SecurityOfficer: [ 3, 4 ]
             SecurityCadet: [ 3, 3 ]
             Detective: [ 1, 1 ]
+            Brigmedic: [ 1, 1 ] # Corvax-Next-Brigmedic
             # service
             HeadOfPersonnel: [ 1, 1 ]
             Bartender: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/pearl.yml
+++ b/Resources/Prototypes/Corvax/Maps/pearl.yml
@@ -49,6 +49,7 @@
             SecurityCadet: [ 1, 1 ]
             Detective: [ 1, 1 ]
             Pilot: [ 2, 2 ]
+            Brigmedic: [ 1, 1 ] # Corvax-Next-Brigmedic
             # service
             HeadOfPersonnel: [ 1, 1 ]
             Bartender: [ 2, 2 ]

--- a/Resources/Prototypes/Corvax/Maps/pilgrim.yml
+++ b/Resources/Prototypes/Corvax/Maps/pilgrim.yml
@@ -48,6 +48,7 @@
             SecurityCadet: [ 3, 3 ]
             Detective: [ 1, 1 ]
             Pilot: [ 2, 2 ]
+            Brigmedic: [ 1, 1 ] # Corvax-Next-Brigmedic
             # service
             HeadOfPersonnel: [ 1, 1 ]
             Bartender: [ 1, 1 ]


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Добавляет роль бригмедика ( #31 ), использует уже замапленные кочергой спавнеры (https://github.com/space-syndicate/space-station-14/pull/2759)
## Почему / Баланс
Бригмедик теперь полностью в игре!

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**
:cl:
- add: Добавлена роль бригмедика на Астру
- add: Добавлена роль бригмедика на Аврит
- add: Добавлена роль бригмедика на Дельту
- add: Добавлена роль бригмедика на Маус
- add: Добавлена роль бригмедика на Пейпер
- add: Добавлена роль бригмедика на Пёрл
- add: Добавлена роль бригмедика на Пилгрим