### PR TITLE
Zombie buff

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -36,6 +36,7 @@ using Content.Shared.Prying.Components;
 using Content.Shared.Traits.Assorted;
 using Robust.Shared.Audio.Systems;
 using Content.Shared.Ghost.Roles.Components;
+using Content.Shared.Damage.Components;
 
 namespace Content.Server.Zombies;
 
@@ -106,6 +107,7 @@ public sealed partial class ZombieSystem
         RemComp<ReproductivePartnerComponent>(target);
         RemComp<LegsParalyzedComponent>(target);
         RemComp<ComplexInteractionComponent>(target);
+        RemComp<SlowOnDamageComponent>(target);
 
         //funny voice
         var accentType = "zombie";
@@ -183,6 +185,18 @@ public sealed partial class ZombieSystem
             pryComp.Force = true;
 
             Dirty(target, pryComp);
+
+            // Humanoid zombie now deals stamina damage! ye.
+            AddComp<StaminaDamageOnHitComponent>(target);
+            var staminDamage = EnsureComp<StaminaDamageOnHitComponent>(target);
+            staminDamage.Damage = 20f;
+
+            Dirty(target, staminDamage);
+
+            var staminaHp = EnsureComp<StaminaComponent>(target)
+            staminaHp.CritThreshold = 200f
+
+            Dirty(target, staminaHp)
         }
 
         Dirty(target, melee);

--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -193,10 +193,10 @@ public sealed partial class ZombieSystem
 
             Dirty(target, staminDamage);
 
-            var staminaHp = EnsureComp<StaminaComponent>(target)
-            staminaHp.CritThreshold = 200f
+            var staminaHp = EnsureComp<StaminaComponent>(target);
+            staminaHp.CritThreshold = 200f;
 
-            Dirty(target, staminaHp)
+            Dirty(target, staminaHp);
         }
 
         Dirty(target, melee);

--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -172,8 +172,8 @@ public sealed partial class ZombieSystem
                 DamageDict = new()
                 {
                     { "Slash", 13 },
-                    { "Piercing", 7 },
-                    { "Structural", 10 }
+                    { "Piercing", 8 },
+                    { "Structural", 20 }
                 }
             };
             melee.Damage = dspec;
@@ -189,7 +189,7 @@ public sealed partial class ZombieSystem
             // Humanoid zombie now deals stamina damage! ye.
             AddComp<StaminaDamageOnHitComponent>(target);
             var staminDamage = EnsureComp<StaminaDamageOnHitComponent>(target);
-            staminDamage.Damage = 20f;
+            staminDamage.Damage = 25f;
 
             Dirty(target, staminDamage);
 

--- a/Content.Shared/Zombies/PendingZombieComponent.cs
+++ b/Content.Shared/Zombies/PendingZombieComponent.cs
@@ -17,7 +17,8 @@ public sealed partial class PendingZombieComponent : Component
     {
         DamageDict = new ()
         {
-            { "Poison", 0.2 },
+            { "Poison", 0.3 },
+            { "Cellular", 0.1 },
         }
     };
 
@@ -40,7 +41,7 @@ public sealed partial class PendingZombieComponent : Component
     /// The minimum amount of time initial infected have before they start taking infection damage.
     /// </summary>
     [DataField]
-    public TimeSpan MinInitialInfectedGrace = TimeSpan.FromMinutes(12.5f);
+    public TimeSpan MinInitialInfectedGrace = TimeSpan.FromMinutes(6f);
 
     /// <summary>
     /// The maximum amount of time initial infected have before they start taking damage.

--- a/Content.Shared/Zombies/PendingZombieComponent.cs
+++ b/Content.Shared/Zombies/PendingZombieComponent.cs
@@ -17,8 +17,8 @@ public sealed partial class PendingZombieComponent : Component
     {
         DamageDict = new ()
         {
-            { "Poison", 0.3 },
-            { "Cellular", 0.1 },
+            { "Poison", 0.5 },
+            { "Cellular", 0.2 },
         }
     };
 
@@ -26,7 +26,7 @@ public sealed partial class PendingZombieComponent : Component
     /// A multiplier for <see cref="Damage"/> applied when the entity is in critical condition.
     /// </summary>
     [DataField("critDamageMultiplier")]
-    public float CritDamageMultiplier = 10f;
+    public float CritDamageMultiplier = 15f;
 
     [DataField("nextTick", customTypeSerializer:typeof(TimeOffsetSerializer))]
     public TimeSpan NextTick;

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -30,7 +30,7 @@ public sealed partial class ZombieComponent : Component
     public float MinZombieInfectionChance = 0.40f;
 
     [ViewVariables(VVAccess.ReadWrite)]
-    public float ZombieMovementSpeedDebuff = 0.90f;
+    public float ZombieMovementSpeedDebuff = 0.80f;
 
     /// <summary>
     /// The skin color of the zombie
@@ -121,9 +121,10 @@ public sealed partial class ZombieComponent : Component
     {
         DamageDict = new()
         {
-            { "Blunt", -2 },
-            { "Slash", -2 },
-            { "Piercing", -2 }
+            { "Blunt", -5 },
+            { "Slash", -5 },
+            { "Piercing", -5 },
+            { "Heat", -2 }
         }
     };
 

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -20,17 +20,17 @@ public sealed partial class ZombieComponent : Component
     /// The baseline infection chance you have if you are completely nude
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    public float MaxZombieInfectionChance = 0.80f;
+    public float MaxZombieInfectionChance = 0.90f;
 
     /// <summary>
     /// The minimum infection chance possible. This is simply to prevent
     /// being invincible by bundling up.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    public float MinZombieInfectionChance = 0.25f;
+    public float MinZombieInfectionChance = 0.40f;
 
     [ViewVariables(VVAccess.ReadWrite)]
-    public float ZombieMovementSpeedDebuff = 0.70f;
+    public float ZombieMovementSpeedDebuff = 0.90f;
 
     /// <summary>
     /// The skin color of the zombie
@@ -99,11 +99,11 @@ public sealed partial class ZombieComponent : Component
     {
         DamageDict = new ()
         {
-            { "Blunt", -0.4 },
-            { "Slash", -0.2 },
-            { "Piercing", -0.2 },
-            { "Heat", -0.02 },
-            { "Shock", -0.02 }
+            { "Blunt", -0.8 },
+            { "Slash", -0.4 },
+            { "Piercing", -0.4 },
+            { "Heat", -0.05 },
+            { "Shock", -0.05 }
         }
     };
 


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Бафф зомби. Если точнее то большая часть характеристик у зомби были бафнуты - дабы сделать их серьезной угрозой для станции. Сразу говорю! Это мой первый PR в жизни! возможны ошибки!

## Почему / Баланс
Сейчас зомби крайне слабые, они редко побеждают в раундах, а процент заражения станции к концу раунда редко достигает хотя-бы 40%. Самих зомби игроки уже просто прозвали грушами для битья - их легко убить особенно на расстоянии. Сами же игроки на зомби часто жаловались на ужасную скорость зомби. 
Раунды где богами рандома выпадала зомба становились очень скучными, зомбей подавляли за 10-20 минут после вспышки, заражались лишь сами нулевые и невнимательные игроки. А те ко и заразился от вируса - мог дожить до конца раунда просто чилово подождав Амбузол. Пока ждут амбузол они просто едят/пьют диловен или СПЯТ В КРОВАТИ. Реген от кровати > урон от вируса.
Я бафнул зомби по всем фронтам и сделал их более менее опасными, вирус теперь настигнет тебя в любом случае, так как помимо урона ядами(сам урон от ядов вырос в 2,5 раза), так и еще наносится клеточный урон, который вообще никак нельзя откатить или замедлить. По моей идее с этими бафами вирус будет крайне быстро распространяться по станции, а сами зомби вблизи смогут забивать даже СБшников 1 на 1. 
Как это изменит геймплей режима? Вспышка вируса станет вот именно вспышкой - нулевые сразу смогут заразить кучу людей, а те кто сбежит лишь сильнее распространят заразу. Игроки начнут держать дистанцию от зомби, так как уменьшение дистанции может стать фатальным для не зараженного. Игроки вновь начнут застраиваться в отделах, они снова начнут толпами сидеть в химке. Сам раунд станет куда быстрее и динамичнее, а выжить в нем будет сложно.

## Ссылка на ветку
(https://discord.com/channels/919301044784226385/1305807770779390033)

## Технические детали
в основном было заменено несколько цифорок и добавлено немножко строчек кода что добавляли компоненты зомби.

**Список изменений**
:cl:
- add: Зомби теперь наносят урон Стамине в размере 25 единиц
- tweak: Стамина зомби повышена со 100 до 200
 - tweak: Структурный урон зомби  поднят с 10 до 20
 - tweak: Урон от вируса изменен со 0.2 Ядами в сек  до 0.5 Ядами 0.2 Клеточными
 - tweak: Регенерация зомби повышена в 2 раза, бафф регенерации в крит состоянии поднята с 10 раз до 15.
 - tweak: Максимальный шанс заражения(Жертва вообще голая) поднята с 80% до 90%, минимальный шанс(тяжелая броня или скаф) с 25% до 40%
 - tweak: Дебаф скорости зомби изменен с 70% до 80%
 - tweak: Регенерация от ударов по живым организмам(вампиризм) повышен в 2,5 раза
 - tweak: Зомби больше не замедляются от урона

