### PR TITLE
Possible TTS fix 2

### DIFF
--- a/Content.Client/Corvax/TTS/TTSSystem.cs
+++ b/Content.Client/Corvax/TTS/TTSSystem.cs
@@ -25,7 +25,7 @@ public sealed class TTSSystem : EntitySystem
     private static MemoryContentRoot _contentRoot = new();
     private static readonly ResPath Prefix = ResPath.Root / "TTS";
 
-    private bool _contentRootAdded;
+    private static bool _contentRootAdded;
 
     /// <summary>
     /// Reducing the volume of the TTS when whispering. Will be converted to logarithm.

--- a/Content.Client/Corvax/TTS/TTSSystem.cs
+++ b/Content.Client/Corvax/TTS/TTSSystem.cs
@@ -22,8 +22,10 @@ public sealed class TTSSystem : EntitySystem
     [Dependency] private readonly AudioSystem _audio = default!;
 
     private ISawmill _sawmill = default!;
-    private MemoryContentRoot _contentRoot = default!;
+    private static MemoryContentRoot _contentRoot = new();
     private static readonly ResPath Prefix = ResPath.Root / "TTS";
+
+    private bool _contentRootAdded;
 
     /// <summary>
     /// Reducing the volume of the TTS when whispering. Will be converted to logarithm.
@@ -40,9 +42,13 @@ public sealed class TTSSystem : EntitySystem
 
     public override void Initialize()
     {
-        _contentRoot = new();
+        if (!_contentRootAdded)
+        {
+            _contentRootAdded = true;
+            _res.AddRoot(Prefix, _contentRoot);
+        }
+
         _sawmill = Logger.GetSawmill("tts");
-        _res.AddRoot(Prefix, _contentRoot);
         _cfg.OnValueChanged(CCCVars.TTSVolume, OnTtsVolumeChanged, true);
         SubscribeNetworkEvent<PlayTTSEvent>(OnPlayTTS);
     }
@@ -51,7 +57,6 @@ public sealed class TTSSystem : EntitySystem
     {
         base.Shutdown();
         _cfg.UnsubValueChanged(CCCVars.TTSVolume, OnTtsVolumeChanged);
-        _contentRoot.Dispose();
     }
 
     public void RequestPreviewTTS(string voiceId)


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Вторая попытка починить TTS, который ломается после переподключения.

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
Видимо, новый экземпляр правильно создавался. Но, видимо, не создаётся новый экземпляр `ResourceManager`. То есть добавлялся ContentRoot по указанному пути, его нормально использовали, а когда появлялся новый `ContentRoot`, то он путь не перезаписывал, а баговался. Сейчас мы создаём один `ContentRoot`, не дизпозаем его и добавляем только один раз.

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
<!--
:cl:
- add: Добавлено веселье!
- remove: Удалено веселье!
- tweak: Изменено веселье!
- fix: Исправлено веселье!
-->
:cl:
- fix: Возможно, починен TTS, который ломался после переподключения.
