### PR TITLE
[Tweak] Remove Lizard Diete

### DIFF
--- a/Resources/Prototypes/Body/Organs/reptilian.yml
+++ b/Resources/Prototypes/Body/Organs/reptilian.yml
@@ -4,14 +4,14 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Stomach
-    specialDigestible:
-      tags:
-      - Fruit
-      - ReptilianFood
-      - Meat
-      - Pill
-      - Crayon
-      - Paper
+#    specialDigestible: # Corvax-Next-RemoveLizardDiete
+#      tags:
+#      - Fruit
+#      - ReptilianFood
+#      - Meat
+#      - Pill
+#      - Crayon
+#      - Paper
   - type: SolutionContainerManager
     solutions:
       stomach:


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Убрана принудительная диета у унатхов.

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
Что мы получаем имея этот высер?
- Унатх превращается в раба системы, который не может сожрать шоколадный пончик, потому-что... вселенная не позволяет засунуть его в рот? Потому-что НТ вставило чип, запрещающий унатхам совать определённую еду в рот?...

Почему это нужно вернуть?
- Унатх и так отравится, если сожрёт то что нельзя, но так он хотя-бы **сможет** это сделать, это игра про свободу и её последствия.

## Ссылка на ветку
<!-- Необязательный пункт. Удалите раздел целиком, если он пуст.
Ссылка на ветку обсуждения ПРа в Discord.
Следите, чтобы информация в первом сообщении была актуальной. -->

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**

:cl: PuroSlavKing
- remove: Удалена диета унатхов, они снова могут съесть что-то не то и откинутся.

