### PR TITLE
[Hotfix] Хирургия части тела теперь уничтожаемы

### DIFF
--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -410,6 +410,10 @@ public partial class SharedBodySystem
                 launchCone: splatCone);
         }
 
+        _gibbingSystem.TryGibEntityWithRef(partId, partId, GibType.Gib, GibContentsOption.Drop, ref gibs,
+                playAudio: true, launchGibs: true, launchDirection: splatDirection, launchImpulse: GibletLaunchImpulse * splatModifier,
+                launchImpulseVariance: GibletLaunchImpulseVariance, launchCone: splatCone);
+
         if (HasComp<InventoryComponent>(partId))
         {
             foreach (var item in _inventory.GetHandOrInventoryEntities((partId)))

--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -410,6 +410,7 @@ public partial class SharedBodySystem
                 launchCone: splatCone);
         }
 
+// Corvax-Next-Surgery
         _gibbingSystem.TryGibEntityWithRef(partId, partId, GibType.Gib, GibContentsOption.Drop, ref gibs,
                 playAudio: true, launchGibs: true, launchDirection: splatDirection, launchImpulse: GibletLaunchImpulse * splatModifier,
                 launchImpulseVariance: GibletLaunchImpulseVariance, launchCone: splatCone);


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Части тела сейчас нельзя уничтожить, которые вывалились с тела. Это фиксит баг с вываливанием мозгов с головы и уничтожением частей тела.
<!-- Что вы изменили? -->

## Почему / Баланс
Мозг достать из головы не выйдет простыми способами (slash, blunt, heat уроном), нужна дробилка, мусоропереработчик, миксер и т.д.
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->

## Технические детали
Опечатку исправил, должно было в двух местах удаляться, но почему-то удаляется только со стороны тела.
<!-- Краткое описание изменений в коде для облегчения проверки. -->

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->

:cl:
- fix: Теперь части тела могут быть уничтожены! Например уничтожить голову для получения мозга.
