### PR TITLE
zombie balance fix (no more грууаааа......)

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -189,7 +189,7 @@ public sealed partial class ZombieSystem
             // Humanoid zombie now deals stamina damage! ye.
             AddComp<StaminaDamageOnHitComponent>(target);
             var staminDamage = EnsureComp<StaminaDamageOnHitComponent>(target);
-            staminDamage.Damage = 25f;
+            staminDamage.Damage = 15f;
 
             Dirty(target, staminDamage);
 

--- a/Content.Shared/Zombies/PendingZombieComponent.cs
+++ b/Content.Shared/Zombies/PendingZombieComponent.cs
@@ -17,7 +17,7 @@ public sealed partial class PendingZombieComponent : Component
     {
         DamageDict = new ()
         {
-            { "Poison", 0.5 },
+            { "Poison", 0.4 },
             { "Cellular", 0.2 },
         }
     };
@@ -41,13 +41,13 @@ public sealed partial class PendingZombieComponent : Component
     /// The minimum amount of time initial infected have before they start taking infection damage.
     /// </summary>
     [DataField]
-    public TimeSpan MinInitialInfectedGrace = TimeSpan.FromMinutes(6f);
+    public TimeSpan MinInitialInfectedGrace = TimeSpan.FromMinutes(12f);
 
     /// <summary>
     /// The maximum amount of time initial infected have before they start taking damage.
     /// </summary>
     [DataField]
-    public TimeSpan MaxInitialInfectedGrace = TimeSpan.FromMinutes(15f);
+    public TimeSpan MaxInitialInfectedGrace = TimeSpan.FromMinutes(20f);
 
     /// <summary>
     /// The chance each second that a warning will be shown.

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -27,10 +27,10 @@ public sealed partial class ZombieComponent : Component
     /// being invincible by bundling up.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    public float MinZombieInfectionChance = 0.40f;
+    public float MinZombieInfectionChance = 0.25f;
 
     [ViewVariables(VVAccess.ReadWrite)]
-    public float ZombieMovementSpeedDebuff = 0.80f;
+    public float ZombieMovementSpeedDebuff = 0.7f;
 
     /// <summary>
     /// The skin color of the zombie
@@ -99,9 +99,9 @@ public sealed partial class ZombieComponent : Component
     {
         DamageDict = new ()
         {
-            { "Blunt", -0.8 },
-            { "Slash", -0.4 },
-            { "Piercing", -0.4 },
+            { "Blunt", -0.7 },
+            { "Slash", -0.3 },
+            { "Piercing", -0.3 },
             { "Heat", -0.05 },
             { "Shock", -0.05 }
         }

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -27,10 +27,10 @@ public sealed partial class ZombieComponent : Component
     /// being invincible by bundling up.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    public float MinZombieInfectionChance = 0.25f;
+    public float MinZombieInfectionChance = 0.30f;
 
     [ViewVariables(VVAccess.ReadWrite)]
-    public float ZombieMovementSpeedDebuff = 0.7f;
+    public float ZombieMovementSpeedDebuff = 0.70f;
 
     /// <summary>
     /// The skin color of the zombie

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -30,7 +30,7 @@ public sealed partial class ZombieComponent : Component
     public float MinZombieInfectionChance = 0.30f;
 
     [ViewVariables(VVAccess.ReadWrite)]
-    public float ZombieMovementSpeedDebuff = 0.70f;
+    public float ZombieMovementSpeedDebuff = 0.75f;
 
     /// <summary>
     /// The skin color of the zombie


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
увы, бафать скорость зомби была не лучшей идеей.

## Почему / Баланс
Я не ожидал что повышение скорости на 10% так сильно их ускорит, зомби были через чур быстрыми. + Администратор и некоторые люди жаловались на высокий стамин урон. Все изменения я сделал исходя из наблюдений 3 раундов с бафнутыми зомби(2 с мейна и 1 с атары).

**Список изменений**
:cl:
- tweak: Урон по стамине снижен с 25 до 15
- tweak: Урон от вируса и регенерация зомби была чуть чуть уменьшена(на 0.1)
- tweak: Время через которое вирус начнет убивать повышенно на 5 минут. У игрока в сумме будет максимум 30 минут, а после гарантированная смерть.
- tweak: дебафф к скорости зомби понижена к 75%, У старых зомби было 70, а у жутко бафнутых 80.

-->
