### PR TITLE
[Fix] Laying System SSD tries to stand up infinitely

### DIFF
--- a/Content.Shared/_CorvaxNext/Standing/SharedLayingDownSystem.cs
+++ b/Content.Shared/_CorvaxNext/Standing/SharedLayingDownSystem.cs
@@ -9,6 +9,7 @@ using Content.Shared.DoAfter;
 using Content.Shared.Gravity;
 using Content.Shared.Input;
 using Content.Shared.Interaction;
+using Content.Shared.Mind;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Components;
@@ -55,6 +56,7 @@ public abstract class SharedLayingDownSystem : EntitySystem
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedMindSystem _mindSystem = default!;
 
     [Dependency] private readonly IConfigurationManager _config = default!;
 
@@ -329,7 +331,8 @@ public abstract class SharedLayingDownSystem : EntitySystem
         var args = new DoAfterArgs(EntityManager, uid, layingDown.StandingUpTime, new StandingUpDoAfterEvent(), uid)
         {
             BreakOnHandChange = false,
-            RequireCanInteract = false
+            RequireCanInteract = false,
+            Hidden = !_mindSystem.TryGetMind(uid, out EntityUid _, out MindComponent? _)
         };
 
         if (!_doAfter.TryStartDoAfter(args))


### PR DESCRIPTION
Thats basically happens on client side, because of bugs on DoAfter side.

<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
ССДшники теперь не пытаются встать на ноги когда упали в критическое состояние или погибли.
<!-- Что вы изменили? -->

## Почему / Баланс
Это выглядит ужасно, когда над трупом несколько doAfter'ов, которые никогда не исчезнут, даже если человека "ударить дефибриллятором".
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->

## Ссылка на ветку
<!-- Необязательный пункт. Удалите раздел целиком, если он пуст.
Ссылка на ветку обсуждения ПРа в Discord.
Следите, чтобы информация в первом сообщении была актуальной. -->

## Технические детали
Добавил проверку, что персонаж ССД, если он ССД, то тогда DoAfter скрывается. По сути показывается только для этого ССДшника локально, но так как его не существует, то ничего не происходит и она уходит. Сам баг на стороне клиента.
<!-- Краткое описание изменений в коде для облегчения проверки. -->

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->

:cl:
- fix: Игроки в ССД после смерти больше не пытаются встать на ноги!
