### PR TITLE
[Hotfix] Inventory slots dissapear at roundstart

### DIFF
--- a/Content.Shared/Inventory/InventorySystem.Slots.cs
+++ b/Content.Shared/Inventory/InventorySystem.Slots.cs
@@ -220,7 +220,7 @@ public partial class InventorySystem : EntitySystem
                     _randomHelper.RandomOffset(entityUid, 0.5f);
                 }
             }
-            slot.Disabled = isDisabled;
+            //slot.Disabled = isDisabled; // CorvaxNext: TURNED OFF FEATURE, would be fixed today maybe with proper limbs cutting disables appropriate slot(-s)
             break;
         }
 


### PR DESCRIPTION
Basically reverts disabling feature of limbs cutting

<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Исправил откатив фичу с исчезанием слотов при отрубании конечностей. Эта фича багованная нужно переписать. Сегодня будет пофикшено, но чтобы игроки не страдали, откатил эту фичу со слотами. Слоты будут левитировать, но зато игроки не будут страдать.
<!-- Что вы изменили? -->

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->

## Ссылка на ветку
https://discord.com/channels/919301044784226385/1309856788346044416/1311175685599006730
<!-- Необязательный пункт. Удалите раздел целиком, если он пуст.
Ссылка на ветку обсуждения ПРа в Discord.
Следите, чтобы информация в первом сообщении была актуальной. -->

## Технические детали
Система слотов ломается из-за щиткода на стороне оффов. Я просто закомментировал фичу `//slot.Disable = isDisabled;` в `InventorySystem.Slots.cs`. Вот подробности про багу:
> I think I moved everything related to slot disabling/enabling to a centralized function called ChangeSlotState or something?
> its really messy since `inventorycomponent` and `inventoryslotscomponent` are not the same.
> and inventory slots arent networked since it uses a compreg
<!-- Краткое описание изменений в коде для облегчения проверки. -->

## Медиа
![image](https://github.com/user-attachments/assets/29d5c9cf-2ed1-4ca2-bfd4-3675f3d9950b)

<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->

:cl:
- fix: Теперь раундстартом доступны все слоты под перчатки, наушники, ботинки, головной убор, когда ранее они с шансом были недоступны.
- fix: Теперь отрубание конечностей не убирает возможность взаимодействия с слотом под предмет, например отрубание ног позволяет надеть ботинки.
