### PR TITLE
Вязкость реагентов следов теперь не влияет на скорость движения

### DIFF
--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
@@ -340,7 +340,7 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
 
         _deletionQueue.Remove(entity);
         UpdateSlip(entity, entity.Comp, args.Solution);
-        UpdateSlow(entity, args.Solution, entity.Comp);
+        UpdateSlow(entity, args.Solution, entity.Comp); // Corvax-Next-Footsteps
         UpdateEvaporation(entity, args.Solution);
         UpdateAppearance(entity, entity.Comp);
     }

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
@@ -340,7 +340,7 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
 
         _deletionQueue.Remove(entity);
         UpdateSlip(entity, entity.Comp, args.Solution);
-        UpdateSlow(entity, args.Solution, entity.Comp); // Corvax-Next-Footsteps
+        UpdateSlow(entity, args.Solution, entity.Comp); // Corvax-Next-Footprints
         UpdateEvaporation(entity, args.Solution);
         UpdateAppearance(entity, entity.Comp);
     }
@@ -421,12 +421,12 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
         }
     }
 
-    private void UpdateSlow(EntityUid uid, Solution solution, PuddleComponent component) // Corvax-Next-Footsteps
+    private void UpdateSlow(EntityUid uid, Solution solution, PuddleComponent component) // Corvax-Next-Footprints
     {
-        // Corvax-Next-Footsteps-Start
+        // Corvax-Next-Footprints-Start
         if (!component.ViscosityAffectsMovement)
             return;
-        // Corvax-Next-Footsteps-End
+        // Corvax-Next-Footprints-End
 
         var maxViscosity = 0f;
         foreach (var (reagent, _) in solution.Contents)

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
@@ -340,7 +340,7 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
 
         _deletionQueue.Remove(entity);
         UpdateSlip(entity, entity.Comp, args.Solution);
-        UpdateSlow(entity, args.Solution);
+        UpdateSlow(entity, args.Solution, entity.Comp);
         UpdateEvaporation(entity, args.Solution);
         UpdateAppearance(entity, entity.Comp);
     }
@@ -421,8 +421,13 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
         }
     }
 
-    private void UpdateSlow(EntityUid uid, Solution solution)
+    private void UpdateSlow(EntityUid uid, Solution solution, PuddleComponent component) // Corvax-Next-Footsteps
     {
+        // Corvax-Next-Footsteps-Start
+        if (!component.ViscosityAffectsMovement)
+            return;
+        // Corvax-Next-Footsteps-End
+
         var maxViscosity = 0f;
         foreach (var (reagent, _) in solution.Contents)
         {

--- a/Content.Shared/Fluids/Components/PuddleComponent.cs
+++ b/Content.Shared/Fluids/Components/PuddleComponent.cs
@@ -22,9 +22,9 @@ namespace Content.Shared.Fluids.Components
         [DataField("solutionRef")]
         public Entity<SolutionComponent>? Solution;
 
-        // Corvax-Next-Footsteps-Start
+        // Corvax-Next-Footprints-Start
         [DataField]
         public bool ViscosityAffectsMovement = true;
-        // Corvax-Next-Footsteps-End
+        // Corvax-Next-Footprints-End
     }
 }

--- a/Content.Shared/Fluids/Components/PuddleComponent.cs
+++ b/Content.Shared/Fluids/Components/PuddleComponent.cs
@@ -21,5 +21,10 @@ namespace Content.Shared.Fluids.Components
 
         [DataField("solutionRef")]
         public Entity<SolutionComponent>? Solution;
+
+        // Corvax-Next-Footsteps-Start
+        [DataField]
+        public bool ViscosityAffectsMovement = true;
+        // Corvax-Next-Footsteps-End
     }
 }

--- a/Resources/Prototypes/_CorvaxNext/Entities/Effects/footstep.yml
+++ b/Resources/Prototypes/_CorvaxNext/Entities/Effects/footstep.yml
@@ -34,6 +34,7 @@
   - type: Footprint
   - type: Puddle
     solution: step
+    viscosityAffectsMovement: false
   - type: Appearance
   - type: ExaminableSolution
     solution: step


### PR DESCRIPTION
## Описание PR
Вязкость реагентов в следах теперь не влияют на скорость движения игроков, что ходят на по ним.

## Почему / Баланс
Незачем делать лужи вязких веществ ещё неприятнее

## Технические детали
Поле `ViscosityAffectsMovement` в `PuddleComponent`, отключающее обновление замедления у объекта, если оно `false`

## Медиа
https://github.com/user-attachments/assets/e95eaa69-ab4d-4db4-870b-6c61864fe838

## Критические изменения
нету

**Список изменений**
:cl: csqrb
- tweak: Следы от вязких реагентов больше не замедляют персонажа.
