### PR TITLE
Открытие шлюзов всегда сохраняет отпечатки.

### DIFF
--- a/Content.Server/Doors/Systems/DoorSystem.cs
+++ b/Content.Server/Doors/Systems/DoorSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server.Access;
+using Content.Server.Forensics; // Corvax-Next-DoorForensics
 using Content.Server.Atmos.Components;
 using Content.Server.Atmos.EntitySystems;
 using Content.Shared.Doors.Components;
@@ -11,6 +12,7 @@ namespace Content.Server.Doors.Systems;
 public sealed class DoorSystem : SharedDoorSystem
 {
     [Dependency] private readonly AirtightSystem _airtightSystem = default!;
+    [Dependency] private readonly ForensicsSystem _forensicsSystem = default!; // Corvax-Next-DoorForensics
 
     public override void Initialize()
     {
@@ -50,4 +52,22 @@ public sealed class DoorSystem : SharedDoorSystem
         Dirty(ent, ent.Comp);
         UpdateBoltLightStatus(ent);
     }
+	
+	// Corvax-Next-DoorForensics start
+    public override void StartOpening(EntityUid uid, DoorComponent? door = null, EntityUid? user = null, bool predicted = false)
+    {
+        base.StartOpening(uid, door, user, predicted);
+
+        if (user.HasValue)
+            _forensicsSystem.ApplyEvidence(user.Value, uid);
+    }
+
+    public override void StartClosing(EntityUid uid, DoorComponent? door = null, EntityUid? user = null, bool predicted = false)
+    {
+        base.StartClosing(uid, door, user, predicted);
+
+        if (user.HasValue)
+            _forensicsSystem.ApplyEvidence(user.Value, uid);
+    }
+	// Corvax-Next-DoorForensics end
 }

--- a/Content.Server/Doors/Systems/DoorSystem.cs
+++ b/Content.Server/Doors/Systems/DoorSystem.cs
@@ -53,7 +53,7 @@ public sealed class DoorSystem : SharedDoorSystem
         UpdateBoltLightStatus(ent);
     }
 	
-	// Corvax-Next-DoorForensics start
+	// Corvax-Next-DoorForensics-Start
     public override void StartOpening(EntityUid uid, DoorComponent? door = null, EntityUid? user = null, bool predicted = false)
     {
         base.StartOpening(uid, door, user, predicted);
@@ -69,5 +69,5 @@ public sealed class DoorSystem : SharedDoorSystem
         if (user.HasValue)
             _forensicsSystem.ApplyEvidence(user.Value, uid);
     }
-	// Corvax-Next-DoorForensics end
+	// Corvax-Next-DoorForensics-End
 }

--- a/Content.Server/Forensics/Systems/ForensicsSystem.cs
+++ b/Content.Server/Forensics/Systems/ForensicsSystem.cs
@@ -279,7 +279,7 @@ namespace Content.Server.Forensics
             return DNA;
         }
 
-        private void ApplyEvidence(EntityUid user, EntityUid target)
+        public void ApplyEvidence(EntityUid user, EntityUid target) // Corvax-Next-DoorForensics
         {
             if (HasComp<IgnoresFingerprintsComponent>(target))
                 return;

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -362,7 +362,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
     /// <param name="user"> The user (if any) opening the door</param>
     /// <param name="predicted">Whether the interaction would have been
     /// predicted. See comments in the PlaySound method on the Server system for details</param>
-    public void StartOpening(EntityUid uid, DoorComponent? door = null, EntityUid? user = null, bool predicted = false)
+    public virtual void StartOpening(EntityUid uid, DoorComponent? door = null, EntityUid? user = null, bool predicted = false) // Corvax-Next-DoorForensics
     {
         if (!Resolve(uid, ref door))
             return;
@@ -438,7 +438,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
         return !ev.PerformCollisionCheck || !GetColliding(uid).Any();
     }
 
-    public void StartClosing(EntityUid uid, DoorComponent? door = null, EntityUid? user = null, bool predicted = false)
+    public virtual void StartClosing(EntityUid uid, DoorComponent? door = null, EntityUid? user = null, bool predicted = false) // Corvax-Next-DoorForensics
     {
         if (!Resolve(uid, ref door))
             return;


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Раньше шлюзы сохраняли отпечатки пальцев только если по ним прямо ткнуть мышкой. Если просто проходить сквозь них, то ничего не сохранялось.

Теперь при открытии шлюза тушкой (что подразумевает, что вы типа открываете шлюз рукой) отпечатки пальцев так же сохраняются на двери и могут быть просканированы анализатором детектива. Прохождение через уже открытый шлюз не сохраняет отпечатки.

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
Потому что текущее состояние этой системы, требующее именно нажатия на дверь мышкой для сохранения отпечатков - бред.

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->

:cl:
- tweak: Все шлюзы теперь всегда сохраняют отпечатки пальцев (или тип перчаток) при их открытии проходом через них, а не только когда по ним жмешь курсором для открытия.
