### PR TITLE
Фикс дюпа реагентов через следы

### DIFF
--- a/Content.Server/_CorvaxNext/Footprints/EntitySystems/FootprintsSystem.cs
+++ b/Content.Server/_CorvaxNext/Footprints/EntitySystems/FootprintsSystem.cs
@@ -97,7 +97,7 @@ public sealed class FootprintsSystem : EntitySystem
         if (string.IsNullOrWhiteSpace(component.ReagentToTransfer) || solution.Volume >= 1)
             return;
 
-        _solution.TryAddReagent(footPrintComponent.Solution.Value, component.ReagentToTransfer, 1, out _);
+        _solution.TryAddReagent(footPrintComponent.Solution.Value, component.ReagentToTransfer, 0.5, out _);
     }
 
     private EntityCoordinates CalcCoords(EntityUid uid, FootprintVisualizerComponent component, TransformComponent transform, bool state)


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Убирает дюп реагентов через следы... Путем добавления потерь реагентов (я не виноват в том, как работает код следов)

## Почему / Баланс
Баг

## Технические детали
Я хотел сделать так, чтобы потерь не было. Но к сожалению код следов буквально не даёт это реализовать нормально. По какой-то причине содержимое ног хранится не как микстура с реагентами, а как цвет следа и название реагента. При этом цвет следа может смешиваться и также зависит от прозрачности исходного реагента.

Я жду рефактора.

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->

## Критические изменения


**Список изменений**
:cl: csqrb
- fix: Через следы больше нельзя дюпать реагенты
