### PR TITLE
Улучшение механики автовызова эвакуации для зомби-раундов

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -43,7 +43,7 @@ namespace Content.Server.GameTicking
         // Mainly to avoid allocations.
         private readonly List<EntityCoordinates> _possiblePositions = new();
 
-        private List<EntityUid> GetSpawnableStations()
+        public List<EntityUid> GetSpawnableStations() // Corvax-Next
         {
             var spawnableStations = new List<EntityUid>();
             var query = EntityQueryEnumerator<StationJobsComponent, StationSpawningComponent>();

--- a/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
@@ -33,6 +33,7 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
     [Dependency] private readonly StationSystem _station = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly ZombieSystem _zombie = default!;
+	[Dependency] private readonly GameTicker _gameTicker = default!; // Corvax-Next
 
     public override void Initialize()
     {
@@ -84,7 +85,7 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
                 ("username", data.UserName)));
         }
 
-        var healthy = GetHealthyHumans();
+        var healthy = GetHealthyHumans(true); // Corvax-Next
         // Gets a bunch of the living players and displays them if they're under a threshold.
         // InitialInfected is used for the threshold because it scales with the player count well.
         if (healthy.Count <= 0 || healthy.Count > 2 * antags.Count)
@@ -159,7 +160,7 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
     /// <param name="includeOffStation">Include healthy players that are not on the station grid</param>
     /// <param name="includeDead">Should dead zombies be included in the count</param>
     /// <returns></returns>
-    private float GetInfectedFraction(bool includeOffStation = true, bool includeDead = false)
+    private float GetInfectedFraction(bool includeOffStation = false, bool includeDead = true) // Corvax-Next
     {
         var players = GetHealthyHumans(includeOffStation);
         var zombieCount = 0;
@@ -179,14 +180,14 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
     /// Flying off via a shuttle disqualifies you.
     /// </summary>
     /// <returns></returns>
-    private List<EntityUid> GetHealthyHumans(bool includeOffStation = true)
+    private List<EntityUid> GetHealthyHumans(bool includeOffStation = false) // Corvax-Next
     {
         var healthy = new List<EntityUid>();
 
         var stationGrids = new HashSet<EntityUid>();
         if (!includeOffStation)
         {
-            foreach (var station in _station.GetStationsSet())
+            foreach (var station in _gameTicker.GetSpawnableStations()) // Corvax-Next
             {
                 if (TryComp<StationDataComponent>(station, out var data) && _station.GetLargestGrid(data) is { } grid)
                     stationGrids.Add(grid);
@@ -197,13 +198,13 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
         var zombers = GetEntityQuery<ZombieComponent>();
         while (players.MoveNext(out var uid, out _, out _, out var mob, out var xform))
         {
-            if (!_mobState.IsAlive(uid, mob))
-                continue;
-
-            if (zombers.HasComponent(uid))
-                continue;
-
-            if (!includeOffStation && !stationGrids.Contains(xform.GridUid ?? EntityUid.Invalid))
+			// Corvax-Next-Start
+            if (!_mobState.IsAlive(uid, mob)
+                || HasComp<PendingZombieComponent>(uid) //Do not include infected players in the "Healthy players" list.
+                || HasComp<ZombifyOnDeathComponent>(uid)
+                || zombers.HasComponent(uid)
+                || !includeOffStation && !stationGrids.Contains(xform.GridUid ?? EntityUid.Invalid))
+			// Corvax-Next-End
                 continue;
 
             healthy.Add(uid);


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Изменена механика автоматического вызова шаттла для зомби-режима:  
- Теперь проверка корректно учитывает только **основную станцию**, исключая ЦК, планетарные экспедиции, обломки, шаттлы и всё остальное.  
- Игроки, инфицированные зомби-вирусом, больше не считаются "здоровыми" для расчета вызова шаттла, что предотвращает затягивание раунда.  
- Мертвые игроки-зомби теперь учитываются при вызова шаттла, так как они считаются исключенными из раунда.  
- Игроки, покинувшие станцию, больше не считаются "здоровыми членами экипажа" для вызова шаттла.


## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
Эти изменения предотвращают затягивание раундов зомби-режима. Теперь вызов эвакуационного шаттла будет происходить корректно в случаях, когда большинство игроков исключено из игры (умерло или покинуло станцию). Это улучшит общий игровой процесс и сократит длительность бессмысленных ожиданий.

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
- Функция `_gameTicker.GetSpawnableStations()` используется для проверки станций, что исключает нежелательные локации.
- Проверка "здоровых" игроков была скорректирована для исключения инфицированных.
- Мертвые зомби теперь учитываются для определения условий вызова шаттла.
- Порт с https://github.com/Simple-Station/Einstein-Engines/pull/652


**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->

:cl:
- tweak: Игроки, покинувшие станцию, больше не считаются "здоровыми членами экипажа" при расчете необходимости вызова авто-эвака.
- tweak: Мертвые игроки-зомби, инфицированные игроки и нулевые зараженные теперь считаются за зомби при расчете необходимости автоматичесгого вызова шаттла эвакуации.
