### PR TITLE
Плата мед. биофаба в шкафчике СМО

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -224,6 +224,7 @@
     - id: HandheldCrewMonitor
     - id: Hypospray
     - id: MedicalTechFabCircuitboard
+    - id: MedicalBiofabMachineBoard #Corvax-Next-Surgery
     - id: MedkitFilled
     - id: RubberStampCMO
     - id: MedTekCartridge


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
В шкафчике СМО теперь спавнится плата мед. биофаба

Важно отметить, что плата мед. биофаба не требует никаких частей при сборке. Их добавляет вот этот [PR](https://github.com/space-syndicate/space-station-14-next/pull/142)

## Почему / Баланс
В внутригровом гайде говорится, что плата мед. биофаба есть в шкафчике СМО, но её там нету.
![изображение](https://github.com/user-attachments/assets/ca0b0a5d-b5d6-4c77-9757-5f4c19622f91)

Если она не должна быть раундстартовой в шкафчике СМО, то нужно поправить гайд

## Технические детали
прототипы

## Медиа
![изображение](https://github.com/user-attachments/assets/dbd81a85-5855-4910-8509-59e463ab384b)

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**
:cl: csqrb
- fix: В шкафчие главного врача теперь есть плата медицинского фабрикатора.
