### PR TITLE
[Port] Случайные выстрелы при падении оружия

### DIFF
--- a/Content.Server/_CorvaxNext/Weapons/Ranged/Systems/FireOnDropSystem.cs
+++ b/Content.Server/_CorvaxNext/Weapons/Ranged/Systems/FireOnDropSystem.cs
@@ -1,0 +1,27 @@
+using Content.Shared.Throwing;
+using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Weapons.Ranged.Systems;
+using Robust.Shared.Random;
+
+namespace Content.Server.Weapons.Ranged.Systems;
+
+public sealed class FireOnDropSystem : EntitySystem
+{
+    [Dependency] private readonly SharedGunSystem _gun = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<GunComponent, ThrowDoHitEvent>(HandleLand);
+    }
+
+
+    private void HandleLand(EntityUid uid, GunComponent component, ref ThrowDoHitEvent args)
+    {
+        if (_random.Prob(component.FireOnDropChance))
+            _gun.AttemptShoot(uid, uid, component, Transform(uid).Coordinates.Offset(Transform(uid).LocalRotation.ToVec()));
+    }
+}

--- a/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
@@ -263,6 +263,12 @@ public sealed partial class GunComponent : Component
     /// </summary>
     [DataField]
     public Vector2 DefaultDirection = new Vector2(0, -1);
+	
+    /// <summary>
+    /// Corvax-Next. The percentage chance of a given gun to accidentally discharge if violently thrown into a wall or person
+    /// </summary>
+    [DataField]
+    public float FireOnDropChance = 0.1f;
 }
 
 [Flags]

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_pka.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_pka.yml
@@ -22,6 +22,7 @@
     - SemiAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/kinetic_accel.ogg
+    fireOnDropChance: 1 # Corvax-Next-FireOnDrop
   - type: AmmoCounter
   - type: Appearance
   - type: GenericVisualizer

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -20,6 +20,7 @@
     - SemiAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser.ogg
+    fireOnDropChance: 0.15 # Corvax-Next-FireOnDrop
   - type: Battery
     maxCharge: 1000
     startingCharge: 1000

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -33,6 +33,7 @@
       - FullAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/pistol.ogg
+    fireOnDropChance: 0.3 # Corvax-Next-FireOnDrop
   - type: ChamberMagazineAmmoProvider
     soundRack:
       path: /Audio/Weapons/Guns/Cock/pistol_cock.ogg

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -29,6 +29,7 @@
     - SemiAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/revolver.ogg
+    fireOnDropChance: 0.6 # Corvax-Next-FireOnDrop
   - type: UseDelay
     delay: 0.66
   - type: ContainerContainer

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -25,6 +25,7 @@
   - type: ChamberMagazineAmmoProvider
     soundRack:
       path: /Audio/Weapons/Guns/Cock/sf_rifle_cock.ogg
+    fireOnDropChance: 0.5 # Corvax-Next-FireOnDrop
   - type: ItemSlots
     slots:
       gun_magazine:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -22,10 +22,10 @@
       - FullAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/batrifle.ogg
+    fireOnDropChance: 0.5 # Corvax-Next-FireOnDrop
   - type: ChamberMagazineAmmoProvider
     soundRack:
       path: /Audio/Weapons/Guns/Cock/sf_rifle_cock.ogg
-    fireOnDropChance: 0.5 # Corvax-Next-FireOnDrop
   - type: ItemSlots
     slots:
       gun_magazine:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -29,6 +29,7 @@
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/smg.ogg
     defaultDirection: 1, 0
+    fireOnDropChance: 0.3 # Corvax-Next-FireOnDrop
   - type: ChamberMagazineAmmoProvider
     soundRack:
       path: /Audio/Weapons/Guns/Cock/smg_cock.ogg

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -28,6 +28,7 @@
       path: /Audio/Weapons/Guns/Gunshots/shotgun.ogg
     soundEmpty:
       path: /Audio/Weapons/Guns/Empty/empty.ogg
+    fireOnDropChance: 0.3 # Corvax-Next-FireOnDrop
   - type: BallisticAmmoProvider
     whitelist:
       tags:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -25,6 +25,7 @@
     - SemiAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/sniper.ogg
+    fireOnDropChance: 0.9 # Corvax-Next-FireOnDrop
   - type: BallisticAmmoProvider
     capacity: 10
     proto: CartridgeLightRifle


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Теперь если бросить оружие оно имеет небольшой шанс выстрелить при столкновении с другим объектом.
Портировано с https://github.com/Simple-Station/Einstein-Engines/pull/471

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
Fun.

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->
https://github.com/user-attachments/assets/1a093378-c9c8-480c-a445-dc2b258cb392


## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->
Было внедрено дополнительное поле в GunComponent

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->

:cl:
- add: Оружие имеет небольшой шанс выстрелить в случайном направлении при падении.
