### PR TITLE
Настраиваемые турели

### DIFF
--- a/Content.Shared/Verbs/VerbCategory.cs
+++ b/Content.Shared/Verbs/VerbCategory.cs
@@ -85,5 +85,7 @@ namespace Content.Shared.Verbs
         public static readonly VerbCategory SelectType = new("verb-categories-select-type", null);
 
         public static readonly VerbCategory PowerLevel = new("verb-categories-power-level", null);
+
+        public static readonly VerbCategory TurretControlMode = new("verb-categories-turret-control-mode", null); // Corvax-Next-TurretControl
     }
 }

--- a/Content.Shared/_CorvaxNext/TurretControl/TurretControlComponent.cs
+++ b/Content.Shared/_CorvaxNext/TurretControl/TurretControlComponent.cs
@@ -1,0 +1,4 @@
+namespace Content.Shared._CorvaxNext.TurretControl;
+
+[RegisterComponent]
+public sealed partial class TurretControlComponent : Component;

--- a/Content.Shared/_CorvaxNext/TurretControl/TurretControlSystem.cs
+++ b/Content.Shared/_CorvaxNext/TurretControl/TurretControlSystem.cs
@@ -1,9 +1,28 @@
+using Content.Shared.NPC.Components;
+using Content.Shared.NPC.Prototypes;
+using Content.Shared.NPC.Systems;
+using Content.Shared.Tag;
 using Content.Shared.Verbs;
 
 namespace Content.Shared._CorvaxNext.TurretControl;
 
 public sealed class TurretControlSystem : EntitySystem
 {
+    [Dependency] private readonly NpcFactionSystem _faction = default!;
+    [Dependency] private readonly TagSystem _tag = default!;
+
+    [ValidatePrototypeId<TagPrototype>]
+    private const string ControlTag = "StationAi";
+
+    [ValidatePrototypeId<NpcFactionPrototype>]
+    private const string Passive = "TurretPassive";
+
+    [ValidatePrototypeId<NpcFactionPrototype>]
+    private const string Peace = "TurretPeace";
+
+    [ValidatePrototypeId<NpcFactionPrototype>]
+    private const string Hostile = "TurretHostile";
+
     public override void Initialize()
     {
         SubscribeLocalEvent<TurretControlComponent, GetVerbsEvent<Verb>>(OnGetVerbs);
@@ -11,6 +30,35 @@ public sealed class TurretControlSystem : EntitySystem
 
     private void OnGetVerbs(Entity<TurretControlComponent> entity, ref GetVerbsEvent<Verb> e)
     {
-        
+        if (!_tag.HasTag(e.User, ControlTag))
+            return;
+
+        if (!TryComp<NpcFactionMemberComponent>(entity, out var factionMember))
+            return;
+
+        e.Verbs.Add(CreateVerb((entity, factionMember), "turret-control-mode-nobody", Passive, 3));
+        e.Verbs.Add(CreateVerb((entity, factionMember), "turret-control-mode-hostile", Peace, 2));
+        e.Verbs.Add(CreateVerb((entity, factionMember), "turret-control-mode-everybody", Hostile, 1));
+    }
+
+    private Verb CreateVerb(Entity<NpcFactionMemberComponent?> entity, string text, string faction, int priority)
+    {
+        return new()
+        {
+            Text = Loc.GetString(text),
+            Disabled = _faction.IsMember(entity, faction),
+            Category = VerbCategory.TurretControlMode,
+            Priority = priority,
+            Act = () => SetFaction(entity, faction)
+        };
+    }
+
+    private void SetFaction(Entity<NpcFactionMemberComponent?> entity, string faction)
+    {
+        _faction.RemoveFaction(entity, Passive);
+        _faction.RemoveFaction(entity, Peace);
+        _faction.RemoveFaction(entity, Hostile);
+
+        _faction.AddFaction(entity, faction);
     }
 }

--- a/Content.Shared/_CorvaxNext/TurretControl/TurretControlSystem.cs
+++ b/Content.Shared/_CorvaxNext/TurretControl/TurretControlSystem.cs
@@ -1,0 +1,16 @@
+using Content.Shared.Verbs;
+
+namespace Content.Shared._CorvaxNext.TurretControl;
+
+public sealed class TurretControlSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<TurretControlComponent, GetVerbsEvent<Verb>>(OnGetVerbs);
+    }
+
+    private void OnGetVerbs(Entity<TurretControlComponent> entity, ref GetVerbsEvent<Verb> e)
+    {
+        
+    }
+}

--- a/Resources/Locale/ru-RU/_corvaxnext/turret-control.ftl
+++ b/Resources/Locale/ru-RU/_corvaxnext/turret-control.ftl
@@ -1,0 +1,3 @@
+turret-control-mode-nobody = Никто
+turret-control-mode-hostile = Враждебные
+turret-control-mode-everybody = Все

--- a/Resources/Locale/ru-RU/_corvaxnext/verbs.ftl
+++ b/Resources/Locale/ru-RU/_corvaxnext/verbs.ftl
@@ -1,0 +1,1 @@
+verb-categories-turret-control-mode = Задать цель

--- a/Resources/Locale/ru-RU/ss14-ru/prototypes/_corvaxnext/entities/objects/weapons/guns/turrets.ftl
+++ b/Resources/Locale/ru-RU/ss14-ru/prototypes/_corvaxnext/entities/objects/weapons/guns/turrets.ftl
@@ -1,0 +1,3 @@
+ent-WeaponTurretControl = { ent-BaseWeaponTurret }
+    .desc = { ent-BaseWeaponTurret.desc }
+    .suffix = Управляемая

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
@@ -185,6 +185,7 @@
   - type: NpcFactionMember
     factions:
     - NanoTrasen
+  - type: TurretControl # Corvax-Next-TurretControl
 
 - type: entity
   parent: BaseWeaponTurret

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
@@ -185,7 +185,6 @@
   - type: NpcFactionMember
     factions:
     - NanoTrasen
-  - type: TurretControl # Corvax-Next-TurretControl
 
 - type: entity
   parent: BaseWeaponTurret

--- a/Resources/Prototypes/_CorvaxNext/Entities/Objects/Weapons/Guns/turrets.yml
+++ b/Resources/Prototypes/_CorvaxNext/Entities/Objects/Weapons/Guns/turrets.yml
@@ -1,0 +1,9 @@
+- type: entity
+  parent: BaseWeaponTurret
+  id: WeaponTurretControl
+  suffix: Control
+  components:
+  - type: NpcFactionMember
+    factions:
+    - TurretPeace
+  - type: TurretControl

--- a/Resources/Prototypes/_CorvaxNext/ai_factions.yml
+++ b/Resources/Prototypes/_CorvaxNext/ai_factions.yml
@@ -1,0 +1,24 @@
+- type: npcFaction
+  id: TurretPassive
+
+- type: npcFaction
+  id: TurretPeace
+  hostile:
+  - Dragon
+  - SimpleHostile
+  - Xeno
+
+- type: npcFaction
+  id: TurretHostile
+  hostile:
+  - Dragon
+  - NanoTrasen
+  - Mouse
+  - Passive
+  - PetsNT
+  - SimpleHostile
+  - SimpleNeutral
+  - Syndicate
+  - Xeno
+  - Zombie
+  - Revolutionary


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Теперь ЦИИ может с помощью ПКМ настроить турели на атаку по определённым целям.
Есть 3 режима целей:
- Никто
- Враждебные
- Все

Но он может настраивать только турели с определённым компонентом, которых пока что нет на картах.

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
Возможность противостоять АПИИ и дракону.

## Ссылка на ветку
<!-- Необязательный пункт. Удалите раздел целиком, если он пуст.
Ссылка на ветку обсуждения ПРа в Discord.
Следите, чтобы информация в первом сообщении была актуальной. -->
https://discord.com/channels/919301044784226385/1319063870073081891

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
<!--
:cl:
- add: Добавлено веселье!
- remove: Удалено веселье!
- tweak: Изменено веселье!
- fix: Исправлено веселье!
-->
:cl:
- add: Теперь ЦИИ может настраивать, по кому бьют турели. Требует маппинга.
