### PR TITLE
Balance Events MRP

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -45,8 +45,10 @@
   components:
   - type: GameRule
     delay:
-      min:  10
-      max:  20
+# Corvax-Next-MRP-Start
+      min:  610 # 10 min
+      max:  900 # 15 min
+# Corvax-Next-MRP-End
 
 - type: entity
   id: BaseStationEventShortDelay
@@ -161,8 +163,10 @@
   id: DragonSpawn
   components:
   - type: StationEvent
-    weight: 6.5
-    earliestStart: 40
+  #Corvax-Next-MRP
+    weight: 4.5
+    earliestStart: 80
+  #Corvax-Next-MRP
     reoccurrenceDelay: 20
     minimumPlayers: 20
     duration: null
@@ -466,8 +470,10 @@
   id: LoneOpsSpawn
   components:
   - type: StationEvent
+  #Corvax-Next-MRP-Start
     earliestStart: 35
-    weight: 5.5
+    weight: 4.5
+  #Corvax-Next-MRP-End
     minimumPlayers: 20
     duration: 1
   - type: RuleGrids
@@ -501,7 +507,7 @@
   id: SleeperAgents
   components:
   - type: StationEvent
-    earliestStart: 30
+    earliestStart: 75 #Corvax-Next-MRP
     weight: 8
     minimumPlayers: 15
     maxOccurrences: 1 # can only happen once per round

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -3,6 +3,11 @@
   abstract: true
   components:
   - type: GameRule
+  # Corvax-Next-MRP-Start
+    delay:
+      min:  610 # 10 min
+      max:  900 # 15 min
+  # Corvax-Next-MRP-End
 
 - type: entity
   parent: BaseGameRule


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Ребаланс событий для МРП отыгрыша путем увилечение времени срабатывания между событиями.
Попытка №2 для некста на основе **принятой** предложки.



## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->

Текущая частота срабатывания ивентов серьезно затрудняет MRP-отыгрыш. Каждый раунд превращается в борьбу за выживание, кульминацией которой становится появление крупного антагониста. Предлагаемые изменения помогут увеличить промежутки между мидраунд-ивентами и слегка сократить частоту появления крупных антагонистов и их пересечение между собой, что сделает раунды более сбалансированными и разнообразными.

**Почему текущие условия, характерные для офов, нам не подходят?**
В отличие от нас, у офов нет глобальной цели, а их раунды изначально сосредоточены на выживании. У нас же основная задача заключается в достижении "постройки цели". Постоянная атмосфера выживания разрушает возможность глубокого отыгрыша ролей, сводя игровой процесс к "игромехану". Чтобы сохранить уникальность нашего сервера, важно создать условия, где у игроков будет пространство для полноценного RP взаимодействия.

## Ссылка на ветку
<!-- Необязательный пункт. Удалите раздел целиком, если он пуст.
Ссылка на ветку обсуждения ПРа в Discord.
Следите, чтобы информация в первом сообщении была актуальной. -->
https://discord.com/channels/919301044784226385/1278711601201021121

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->

- События в раунде срабатывают с частотой от 10 - 15 минут
- Слегка уменьшен шанс одинокого оперативника, теперь появляется не каждый раунд.
- Слегка уменьшен шанс дракона, появляется теперь на 80 минуте, а не 40 как ранее, что снижает шансы появлеения совместно с одиноким оперативником.
- Спящие агенты агенты появляются через час, а не через 30 минут.


:cl:Krosus
- tweak: Ребаланс событий в раунде.


