### PR TITLE
Система автоматического телепортирования в криокапсулы

### DIFF
--- a/Content.Shared/_CorvaxNext/NextVars.cs
+++ b/Content.Shared/_CorvaxNext/NextVars.cs
@@ -17,7 +17,7 @@ public sealed class NextVars
         CVarDef.Create("auto_cryo_sleep.enabled", true, CVar.SERVER);
 
     public static readonly CVarDef<int> AutoCryoSleepTime =
-        CVarDef.Create("auto_cryo_sleep.time", 500, CVar.SERVER);
+        CVarDef.Create("auto_cryo_sleep.time", 1200, CVar.SERVER);
 
     public static readonly CVarDef<int> AutoCryoSleepUpdateTime =
         CVarDef.Create("auto_cryo_sleep.update_time", 120, CVar.SERVER);

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -217,6 +217,7 @@
   - type: Targeting # _CorvaxNext: surgery
   - type: SurgeryTarget # _CorvaxNext: surgery
   - type: LayingDown # _CorvaxNext: LayingDown Laying Down
+  - type: AutoCryoSleepable # Corvax-Next-AutoCryo
 
 - type: entity
   save: false


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Продолжение вот этого PRа - https://github.com/space-syndicate/space-station-14-next/pull/209
Теперь все игроки, чьи тела живы и находятся на станции, будут автоматически телепортироваться в криокамеру спустя 20 минут после выхода с сервера для освобождения занимаемой должности.
Всё авторство кода принадлежит автору оригинального PRа, я просто включаю его действие и увеличиваю таймер до 20 минут по итогам тестирования.

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
Небольшой QOL для освобождения занятых ролей, в случае если какой-нибудь клоун резко вышел из игры будучи в техах и никем не был найден.

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
Всем тушкам добавлен компонент AutoCryoSleepable, который запускает двадцатиминутный таймер по выходу игрока с сервера.



**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->

:cl:
- add: Теперь все живые игроки, вышедшие с сервера и находящиеся на станции, автоматически телепортируются в криокапсулы спустя 20 минут.
