### PR TITLE
Дионы теперь не падают при БСС

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
+using Content.Server._CorvaxNext.FTLKnockdownImmune;
 using Content.Server.Shuttles.Components;
 using Content.Server.Shuttles.Events;
 using Content.Server.Station.Events;
@@ -631,7 +632,10 @@ public sealed partial class ShuttleSystem
                 if (!_statusQuery.TryGetComponent(child, out var status))
                     continue;
 
-                _stuns.TryParalyze(child, _hyperspaceKnockdownTime, true, status);
+                // Corvax-Next-FTLImmune-Start
+                if (!HasComp<FTLKnockdownImmuneComponent>(child))
+                    _stuns.TryParalyze(child, _hyperspaceKnockdownTime, true, status);
+                // Corvax-Next-FTLImmune-End
 
                 // If the guy we knocked down is on a spaced tile, throw them too
                 if (grid != null)

--- a/Content.Server/_CorvaxNext/FTLKnockdownImmune/FTLKnockdownImmuneComponent.cs
+++ b/Content.Server/_CorvaxNext/FTLKnockdownImmune/FTLKnockdownImmuneComponent.cs
@@ -1,7 +1,7 @@
 namespace Content.Server._CorvaxNext.FTLKnockdownImmune;
 
 /// <summary>
-///     Denotes an entity as being immune from knockdown on FTL
+/// Denotes an entity as being immune from knockdown on FTL
 /// </summary>
 [RegisterComponent]
 public sealed partial class FTLKnockdownImmuneComponent : Component;

--- a/Content.Server/_CorvaxNext/FTLKnockdownImmune/FTLKnockdownImmuneComponent.cs
+++ b/Content.Server/_CorvaxNext/FTLKnockdownImmune/FTLKnockdownImmuneComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Server._CorvaxNext.FTLKnockdownImmune;
+
+/// <summary>
+///     Denotes an entity as being immune from knockdown on FTL
+/// </summary>
+[RegisterComponent]
+public sealed partial class FTLKnockdownImmuneComponent : Component;

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -114,6 +114,7 @@
   - type: FootprintVisualizer # Corvax-Next-Footprints
     leftBarePrint: "footprint-left-bare-diona"
     rightBarePrint: "footprint-right-bare-diona"
+  - type: FTLKnockdownImmune # Corvax-Next-FTLImmune
 
 - type: entity
   parent: BaseSpeciesDummy


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Дионы теперь не падают из-за блюспейс прыжков.

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
Потому что лор, они деревья, они крепко стоят на ногах.

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->

:cl:
- tweak: Дионы больше не падают при БСС прыжках на шаттлах.

