### PR TITLE
Багфикс Наночата

### DIFF
--- a/Content.Server/_CorvaxNext/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
+++ b/Content.Server/_CorvaxNext/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
@@ -334,6 +334,7 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
                 // Check if devices are on same map
                 var recipientMap = Transform(receiverUid).MapID;
                 var senderMap = Transform(sender).MapID;
+                
                 // Must be on the same map/station unless long-range is allowed
                 if (!channel.LongRange && recipientMap != senderMap)
                 {

--- a/Content.Server/_CorvaxNext/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
+++ b/Content.Server/_CorvaxNext/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
@@ -12,6 +12,7 @@ using Content.Shared._CorvaxNext.CartridgeLoader.Cartridges;
 using Content.Shared._CorvaxNext.NanoChat;
 using Content.Shared.PDA;
 using Content.Shared.Radio.Components;
+using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
@@ -257,7 +258,7 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
 
         // Log message attempt
         var recipientsText = recipients.Count > 0
-            ? string.Join(", ", recipients.Select(r => ToPrettyString(r)))
+            ? string.Join(", ", recipients.Select((Entity<NanoChatCardComponent> r) => ToPrettyString(r)))
             : $"#{msg.RecipientNumber:D4}";
 
         _adminLogger.Add(LogType.Chat,
@@ -330,21 +331,18 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
                 if (receiverCart.Card != recipient.Owner)
                     continue;
 
-                // Check if devices are on same station/map
-                var recipientStation = _station.GetOwningStation(receiverUid);
-                var senderStation = _station.GetOwningStation(sender);
+                // Check if devices are on same map
+                var recipientMap = Transform(receiverUid).MapID;
+                var senderMap = Transform(sender).MapID;
+                // Must be on the same map/station unless long-range is allowed
+                if (!channel.LongRange && recipientMap != senderMap)
+                {
+                    break;
+                }
 
-                // Both entities must be on a station
-                if (recipientStation == null || senderStation == null)
-                    continue;
-
-                // Must be on same map/station unless long range allowed
-                if (!channel.LongRange && recipientStation != senderStation)
-                    continue;
-
-                // Needs telecomms
-                if (!HasActiveServer(senderStation.Value) || !HasActiveServer(recipientStation.Value))
-                    continue;
+                /* Must have an active common server
+                if (HasActiveServer(senderMap))
+                    continue;*/
 
                 // Check if recipient can receive
                 var receiveAttemptEv = new RadioReceiveAttemptEvent(channel, sender, receiverUid);
@@ -364,7 +362,7 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
     /// <summary>
     ///     Checks if there are any active telecomms servers on the given station
     /// </summary>
-    private bool HasActiveServer(EntityUid station)
+    private bool HasActiveServer(MapId mapId)
     {
         // I have no idea why this isn't public in the RadioSystem
         var query =
@@ -372,7 +370,7 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
 
         while (query.MoveNext(out var uid, out _, out _, out var power))
         {
-            if (_station.GetOwningStation(uid) == station && power.Powered)
+            if (Transform(uid).MapID == mapId && power.Powered)
                 return true;
         }
 

--- a/Content.Server/_CorvaxNext/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
+++ b/Content.Server/_CorvaxNext/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
@@ -399,7 +399,6 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
 
         _nanoChat.AddMessage((recipient, recipient.Comp), senderNumber.Value, message with { DeliveryFailed = false });
 
-
         if (recipient.Comp.IsClosed || _nanoChat.GetCurrentChat((recipient, recipient.Comp)) != senderNumber)
             HandleUnreadNotification(recipient, message);
 

--- a/Content.Server/_CorvaxNext/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
+++ b/Content.Server/_CorvaxNext/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
@@ -24,6 +24,7 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly SharedNanoChatSystem _nanoChat = default!;
+    [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
     [Dependency] private readonly StationSystem _station = default!;
 
     // Messages in notifications get cut off after this point
@@ -38,6 +39,20 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
         SubscribeLocalEvent<NanoChatCartridgeComponent, CartridgeMessageEvent>(OnMessage);
     }
 
+    private void UpdateClosed(Entity<NanoChatCartridgeComponent> ent)
+    {
+        if (!TryComp<CartridgeComponent>(ent, out var cartridge) ||
+            cartridge.LoaderUid is not {} pda ||
+            !TryComp<CartridgeLoaderComponent>(pda, out var loader) ||
+            !GetCardEntity(pda, out var card))
+        {
+            return;
+        }
+
+        // if you switch to another program or close the pda UI, allow notifications for the selected chat
+        _nanoChat.SetClosed((card, card.Comp), loader.ActiveProgram != ent.Owner || !_ui.IsUiOpen(pda, PdaUiKey.Key));
+    }
+
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
@@ -48,6 +63,9 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
         {
             if (cartridge.LoaderUid == null)
                 continue;
+
+            // keep it up to date without handling ui open/close events on the pda or adding code when changing active program
+            UpdateClosed((uid, nanoChat));
 
             // Check if we need to update our card reference
             if (!TryComp<PdaComponent>(cartridge.LoaderUid, out var pda))
@@ -382,7 +400,7 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
         _nanoChat.AddMessage((recipient, recipient.Comp), senderNumber.Value, message with { DeliveryFailed = false });
 
 
-        if (_nanoChat.GetCurrentChat((recipient, recipient.Comp)) != senderNumber)
+        if (recipient.Comp.IsClosed || _nanoChat.GetCurrentChat((recipient, recipient.Comp)) != senderNumber)
             HandleUnreadNotification(recipient, message);
 
         var msgEv = new NanoChatMessageReceivedEvent(recipient);

--- a/Content.Shared/_CorvaxNext/NanoChat/NanoChatCardComponent.cs
+++ b/Content.Shared/_CorvaxNext/NanoChat/NanoChatCardComponent.cs
@@ -15,6 +15,13 @@ public sealed partial class NanoChatCardComponent : Component
     public uint? Number;
 
     /// <summary>
+    ///     Whether a PDA has this card's UI closed.
+    ///     Used for notifications.
+    /// </summary>
+    [DataField]
+    public bool IsClosed;
+
+    /// <summary>
     ///     All chat recipients stored on this card.
     /// </summary>
     [DataField]

--- a/Content.Shared/_CorvaxNext/NanoChat/SharedNanoChatSystem.cs
+++ b/Content.Shared/_CorvaxNext/NanoChat/SharedNanoChatSystem.cs
@@ -49,7 +49,7 @@ public abstract class SharedNanoChatSystem : EntitySystem
     /// </summary>
     public void SetNumber(Entity<NanoChatCardComponent?> card, uint number)
     {
-        if (!Resolve(card, ref card.Comp))
+        if (!Resolve(card, ref card.Comp) || card.Comp.Number == number)
             return;
 
         card.Comp.Number = number;

--- a/Content.Shared/_CorvaxNext/NanoChat/SharedNanoChatSystem.cs
+++ b/Content.Shared/_CorvaxNext/NanoChat/SharedNanoChatSystem.cs
@@ -57,6 +57,17 @@ public abstract class SharedNanoChatSystem : EntitySystem
     }
 
     /// <summary>
+    ///     Sets IsClosed for a card.
+    /// </summary>
+    public void SetClosed(Entity<NanoChatCardComponent?> card, bool closed)
+    {
+        if (!Resolve(card, ref card.Comp))
+            return;
+
+        card.Comp.IsClosed = closed;
+    }
+
+    /// <summary>
     ///     Gets the recipients dictionary from a card.
     /// </summary>
     public IReadOnlyDictionary<uint, NanoChatRecipient> GetRecipients(Entity<NanoChatCardComponent?> card)
@@ -170,7 +181,7 @@ public abstract class SharedNanoChatSystem : EntitySystem
     /// </summary>
     public void SetNotificationsMuted(Entity<NanoChatCardComponent?> card, bool muted)
     {
-        if (!Resolve(card, ref card.Comp))
+        if (!Resolve(card, ref card.Comp) || card.Comp.NotificationsMuted == muted)
             return;
 
         card.Comp.NotificationsMuted = muted;


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Теперь оповещения о сообщениях из НаноЧата появляются даже если КПК и приложение на нём закрыты. Раньше с этим были проблемы.
Теперь НаноЧат работает не на одной станции, а по всей карте (но только в рамках одной карты, с улетевшими утилями не поболтаете).

Порт багфикса наночата - https://github.com/DeltaV-Station/Delta-v/pull/2565
Порт глобализации наночата - https://github.com/impstation/imp-station-14/pull/1055

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
Багфикс.


**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->

:cl:
- fix: Теперь всегда оповещения о новых сообщениях НаноЧата.
- tweak: Теперь НаноЧат доставляет сообщения в радиусе карты, а не станции.

