### PR TITLE
Настоящий фикс бага с длинными руками

### DIFF
--- a/Content.Shared/CombatMode/SharedCombatModeSystem.cs
+++ b/Content.Shared/CombatMode/SharedCombatModeSystem.cs
@@ -35,7 +35,7 @@ public abstract class SharedCombatModeSystem : EntitySystem
     {
         _actionsSystem.RemoveAction(uid, component.CombatToggleActionEntity);
 
-        SetMouseRotatorComponents(uid, false);
+        SetMouseRotatorComponents(uid, false, component);
     }
 
     private void OnActionPerform(EntityUid uid, CombatModeComponent component, ToggleCombatActionEvent args)
@@ -87,16 +87,16 @@ public abstract class SharedCombatModeSystem : EntitySystem
         if (!component.ToggleMouseRotator || IsNpc(entity) && !_mind.TryGetMind(entity, out _, out _))
             return;
 
-        SetMouseRotatorComponents(entity, value);
+        SetMouseRotatorComponents(entity, value, component);
     }
 
-    private void SetMouseRotatorComponents(EntityUid uid, bool value)
+    private void SetMouseRotatorComponents(EntityUid uid, bool value, CombatModeComponent? comp = null)
     {
         if (value)
         {
             // Corvax-Next-NoScope-Start
             var rot = EnsureComp<MouseRotatorComponent>(uid);
-            if (TryComp<CombatModeComponent>(uid, out var comp) && comp.SmoothRotation) // no idea under which (intended) circumstances this can fail (if any), so i'll avoid Comp<>().
+            if (TryComp<CombatModeComponent>(uid, out var combatComp) && combatComp.SmoothRotation) // no idea under which (intended) circumstances this can fail (if any), so i'll avoid Comp<>().
             {
                 rot.AngleTolerance = Angle.FromDegrees(1); // arbitrary
                 rot.Simple4DirMode = false;

--- a/Content.Shared/CombatMode/SharedCombatModeSystem.cs
+++ b/Content.Shared/CombatMode/SharedCombatModeSystem.cs
@@ -35,7 +35,7 @@ public abstract class SharedCombatModeSystem : EntitySystem
     {
         _actionsSystem.RemoveAction(uid, component.CombatToggleActionEntity);
 
-        SetMouseRotatorComponents(uid, false, component);
+        SetMouseRotatorComponents(uid, false, component); // Corvax-Next-NoScope-Fix
     }
 
     private void OnActionPerform(EntityUid uid, CombatModeComponent component, ToggleCombatActionEvent args)
@@ -87,10 +87,10 @@ public abstract class SharedCombatModeSystem : EntitySystem
         if (!component.ToggleMouseRotator || IsNpc(entity) && !_mind.TryGetMind(entity, out _, out _))
             return;
 
-        SetMouseRotatorComponents(entity, value, component);
+        SetMouseRotatorComponents(entity, value, component); // Corvax-Next-NoScope-Fix
     }
 
-    private void SetMouseRotatorComponents(EntityUid uid, bool value, CombatModeComponent? comp = null)
+    private void SetMouseRotatorComponents(EntityUid uid, bool value, CombatModeComponent? comp = null) // Corvax-Next-NoScope-Fix
     {
         if (value)
         {


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Никакого реверта. Надо фиксить. Проблема кроется в том, что при очень быстром вращении мыши, `MouseRotatorComponent` устанавливает `GoalRotation` на новое значение, пока предыдущий поворот ещё не завершен (не достигнут GoalRotation). В результате этого, `MouseRotatorComponent` не успевал сбросить компоненты `MouseRotatorComponent` и `NoRotateOnMoveComponent`, а `TransformComponent` не успевал обновитсья. При этом одновременно оставался `MouseRotatorComponent` и `NoRotateOnMoveComponent`, при этом первый продолжал выставлять поворот. Как-то так.


## Почему / Баланс
<!-- Обсудите, как это повлиет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
Багфикс.

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
*   Функция `SetMouseRotatorComponents` в `SharedCombatModeSystem.cs` теперь принимает `CombatModeComponent` в качестве параметра, чтобы избежать лишнего запроса компонента.
*   В `SetMouseRotatorComponents`, когда `IsInCombatMode` устанавливается в `true`, компоненты `MouseRotatorComponent` и `NoRotateOnMoveComponent` добавляются последовательно, а не одновременно. Сначала добавляется `MouseRotatorComponent` с нужными параметрами и устанавливается поворот, а  компонент `NoRotateOnMoveComponent` добавляется только после завершения поворота (когда `GoalRotation` становится null). Когда `IsInCombatMode` устанавливается в `false` мы сразу удаляем оба компонента.

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->
*   **Изменения в методе `SetMouseRotatorComponents`**:
    *   Метод теперь принимает параметр `CombatModeComponent? comp`, это необходимо для избежания повторного запроса компонента.
    *  Изменена логика добавления компонентов. Теперь  `NoRotateOnMoveComponent` добавляется только когда `GoalRotation` становится null.
    *   Удаление компонентов `MouseRotatorComponent` и `NoRotateOnMoveComponent` происходит одновременно, без условий.

*   **Изменения в методе `OnShutdown`:**
    *   Теперь в метод `SetMouseRotatorComponents` передается второй параметр - компонент.

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->

:cl:
- fix: Пофикшен баг с длинными руками.

