### PR TITLE
Навыходившие фиксы хирургии

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -247,6 +247,7 @@
         Heat: 10 # capable of touching light bulbs and stoves without feeling pain!
   - type: TTS # Corvax-TTS
     voice: TrainingRobot
+  - type: Targeting # Corvax-Next-Surgery
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
@@ -20,7 +20,7 @@
     components:
     #- type: CPRTraining
     - type: SurgerySpeedModifier
-      SpeedModifier: 1.75
+      speedModifier: 1.75
     #end-_CorvaxNext: surgery
 
 - type: startingGear

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -39,7 +39,7 @@
     #start-_CorvaxNext: surgery
     #- type: CPRTraining
     - type: SurgerySpeedModifier
-      SpeedModifier: 2.5
+      speedModifier: 2.5
     #end-_CorvaxNext: surgery
 
 - type: startingGear

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
@@ -21,7 +21,7 @@
     #start-_CorvaxNext: surgery
     #- type: CPRTraining
     - type: SurgerySpeedModifier
-      SpeedModifier: 1.75
+      speedModifier: 1.75
     #end-_CorvaxNext: surgery
 
 - type: startingGear

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
@@ -21,7 +21,7 @@
     #start-_CorvaxNext: surgery
     #- type: CPRTraining
     - type: SurgerySpeedModifier
-      SpeedModifier: 1.5
+      speedModifier: 1.5
     #end-_CorvaxNext: surgery
 
 - type: startingGear

--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -23,7 +23,7 @@
     #start-_CorvaxNext: surgery
     #- type: CPRTraining
     - type: SurgerySpeedModifier
-      SpeedModifier: 1.75
+      speedModifier: 1.75
     #end-_CorvaxNext: surgery
 
 - type: startingGear

--- a/Resources/Prototypes/_CorvaxNext/Roles/Jobs/Medical/surgeon.yml
+++ b/Resources/Prototypes/_CorvaxNext/Roles/Jobs/Medical/surgeon.yml
@@ -15,6 +15,11 @@
   - Maintenance
   extendedAccess:
   - Chemistry
+  special:
+  - !type:AddComponentSpecial
+    components:
+    - type: SurgerySpeedModifier
+      speedModifier: 2.5
 
 - type: startingGear
   id: SurgeonGear

--- a/Resources/Prototypes/_CorvaxNext/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/_CorvaxNext/Roles/Jobs/Security/brigmedic.yml
@@ -25,6 +25,10 @@
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]
+  - !type:AddComponentSpecial
+    components:
+    - type: SurgerySpeedModifier
+      speedModifier: 1.75
 
 - type: startingGear
   id: BrigmedicGear

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -165,6 +165,8 @@
   - type: ShowHealthIcons
     damageContainers:
     - Biological
+  - type: SurgeryTarget # Corvax-Next-Surgery
+  - type: Sanitized # Corvax-Next-Surgery
 
   # Visual
   inventoryTemplateId: borgDutch


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Мелкие фиксы хирургии. Борги вновь могут делать операции, врачи теперь имеют работающий бафф к скорости хирургии, хирург тоже, борги теперь могут выбирать куда целиться как игроки.

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
https://github.com/Goob-Station/Goob-Station/pull/1280 - раньше компонент, ускорявший хирургию для врачей и прочих, банально не работал.
https://github.com/Goob-Station/Goob-Station/pull/1294 - Борги теперь могут выбирать куда бить или лечить.
https://github.com/Goob-Station/Goob-Station/pull/1231 - медборги теперь умеют в хирургию.




**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->

:cl:
- fix: Исправлена работа баффа скорости хирургии.
- fix: Медицинские борги теперь умеют делать операции.
- tweak: Борги теперь могут выбирать куда целиться на тушке человека.

