### PR TITLE
Survival box & cargo prices

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
@@ -4,7 +4,7 @@
     sprite: Objects/Consumable/Food/Baked/pizza.rsi
     state: margherita-slice
   product: CrateFoodPizza
-  cost: 450
+  cost: 900
   category: cargoproduct-category-name-food
   group: market
 
@@ -14,7 +14,7 @@
     sprite: Objects/Consumable/Food/Baked/pizza.rsi
     state: margherita
   product: CrateFoodPizzaLarge
-  cost: 1800
+  cost: 3600
   category: cargoproduct-category-name-food
   group: market
 
@@ -24,7 +24,7 @@
     sprite: Objects/Consumable/Food/snacks.rsi
     state: nutribrick
   product: CrateFoodMRE
-  cost: 1000
+  cost: 2000
   category: cargoproduct-category-name-food
   group: market
 

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -11,7 +11,7 @@
     - id: EmergencyOxygenTankFilled
     - id: EmergencyMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
+    - id: FoodSnackEnergy
     - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -29,7 +29,7 @@
     - id: EmergencyNitrogenTankFilled
     - id: EmergencyMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
+    - id: FoodSnackEnergy
     - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -51,7 +51,7 @@
     - id: ExtendedEmergencyOxygenTankFilled
     - id: EmergencyMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
+    - id: FoodSnackEnergy
     - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -69,7 +69,7 @@
     - id: ExtendedEmergencyNitrogenTankFilled
     - id: EmergencyMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
+    - id: FoodSnackEnergy
     - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -92,7 +92,7 @@
     - id: EmergencyOxygenTankFilled
     - id: EmergencyMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
+    - id: FoodSnackEnergy
     - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -110,7 +110,7 @@
     - id: EmergencyNitrogenTankFilled
     - id: EmergencyMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
+    - id: FoodSnackEnergy
     - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -133,7 +133,7 @@
     - id: EmergencyOxygenTankFilled
     - id: EmergencyMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
+    - id: FoodSnackEnergy
     - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -151,7 +151,7 @@
     - id: EmergencyNitrogenTankFilled
     - id: EmergencyMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
+    - id: FoodSnackEnergy
     - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -179,7 +179,7 @@
     - id: EmergencyFunnyOxygenTankFilled
     - id: EmergencyMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
+    - id: FoodSnackEnergy
     - id: DrinkWaterBottleFull
   - type: Tag
     tags:
@@ -196,7 +196,7 @@
     - id: EmergencyNitrogenTankFilled
     - id: EmergencyMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
+    - id: FoodSnackEnergy
     - id: DrinkWaterBottleFull
   - type: Label
     currentLabel: reagent-name-nitrogen


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
- Шоколадная штука в Аварийном наборе заменена на энергетический батончик.
- Изменена стоимость грузов: 
- - 4 пиццы — 450 -> 900
- - 16 пиццы — 1800 -> 3600
- - ИРП — 1000 -> 2000

## Медиа
![image](https://github.com/user-attachments/assets/4e715122-3f2e-498f-a592-6e6f119a4326)

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
Изменения направлены на увеличение спроса на еду, чтобы люди чаще пользовались услугами повара, и его вклад в раунд был более значительным. Тем самым увеличиваем интерес игры на данной роли.
В скором времени количество торгоматов с едой на хайпоп и мидпоп картах будет тоже порезано,

**Список изменений**
:cl: Ko4erga
- tweak: Еда в аварийном наборе заменена на энергетический батончик.
- tweak: Стоимость заказа грузов с готовой едой была повышена в два раза.
