### PR TITLE
Нулевая задержка перезапуска раунда по прилёту эвака на сцк.

### DIFF
--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -342,7 +342,7 @@ public sealed partial class CCVars
         ///     Defaults to 2 minutes.
         /// </summary>
         public static readonly CVarDef<float> RoundRestartTime =
-            CVarDef.Create("game.round_restart_time", 120f, CVar.SERVERONLY);
+            CVarDef.Create("game.round_restart_time", 0f, CVar.SERVERONLY);
 
         /// <summary>
         ///     The prototype to use for secret weights.

--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -342,7 +342,7 @@ public sealed partial class CCVars
         ///     Defaults to 2 minutes.
         /// </summary>
         public static readonly CVarDef<float> RoundRestartTime =
-            CVarDef.Create("game.round_restart_time", 0f, CVar.SERVERONLY);
+            CVarDef.Create("game.round_restart_time", 120f, CVar.SERVERONLY);
 
         /// <summary>
         ///     The prototype to use for secret weights.

--- a/Resources/ConfigPresets/Corvax/athara.toml
+++ b/Resources/ConfigPresets/Corvax/athara.toml
@@ -4,6 +4,7 @@ desc = "Корвакс — первый русскоязычный проект 
 maxplayers = 150
 soft_max_players = 70
 map_rotation = true
+round_restart_time = 1
 
 [server]
 lobby_name = "🛰️ Corvax — Атара 🌌⚡"

--- a/Resources/ConfigPresets/Corvax/common.toml
+++ b/Resources/ConfigPresets/Corvax/common.toml
@@ -20,6 +20,7 @@ maximum_width = 26
 lobbyduration = 360
 map_pool = "NextMapPool"
 secret_weight_prototype = "CorvaxSecretDefault"
+round_restart_time = 1
 
 [server]
 rules_file = "CorvaxRuleset"

--- a/Resources/ConfigPresets/Corvax/main.toml
+++ b/Resources/ConfigPresets/Corvax/main.toml
@@ -5,6 +5,7 @@ maxplayers = 190
 soft_max_players = 105
 map_rotation = true
 peaceful_end = false
+round_restart_time = 1
 
 [server]
 rules_file = "CorvaxLRPRuleset"

--- a/Resources/ConfigPresets/Corvax/mrp.toml
+++ b/Resources/ConfigPresets/Corvax/mrp.toml
@@ -3,7 +3,7 @@ fallbackpreset = "extended"
 lobbyenabled = true
 role_timers = true
 contraband_examine = false
-round_restart_time = 0f
+round_restart_time = 1
 
 [ic]
 flavor_text = true

--- a/Resources/ConfigPresets/Corvax/mrp.toml
+++ b/Resources/ConfigPresets/Corvax/mrp.toml
@@ -3,6 +3,7 @@ fallbackpreset = "extended"
 lobbyenabled = true
 role_timers = true
 contraband_examine = false
+round_restart_time = 0f
 
 [ic]
 flavor_text = true

--- a/Resources/ConfigPresets/Corvax/solaris.toml
+++ b/Resources/ConfigPresets/Corvax/solaris.toml
@@ -4,6 +4,7 @@ desc = "Корвакс — первый русскоязычный проект 
 maxplayers = 160
 soft_max_players = 115
 map_rotation = true
+round_restart_time = 1
 
 [server]
 lobby_name = "️🛰️ Corvax — Солярис 🌕"


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Предлагаю, в качестве временного изменения, сделать перезапуск раунда почти моментальным. 
А потом собрать фидбек и\или откатить\оставить. 

## Почему / Баланс
На основе небольшого, положительного отклика в предложке.
Правилами запрещено сумасшествие игроков на сцк. РП элемент тоже сомнительный.
Так же не позволит игрокам нарушать правила после манифеста механически. (Защита от дурака)
Но, команда на задержку конца раунда так же доступна

## Ссылка на ветку
https://discord.com/channels/919301044784226385/1339517432309747742

## Технические детали
Изменения в CCvars.Game.cs

**Список изменений**
:cl: TiFeRi
- tweak: Изменено время задержки до перезапуска раунда.
