### PR TITLE
fix-charge

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Power/portable_recharger.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/portable_recharger.yml
@@ -36,3 +36,6 @@
           components:
           - HitscanBatteryAmmoProvider
           - ProjectileBatteryAmmoProvider
+        blacklist:
+           components:  # Goobstation
+           - BatteryRecharge

--- a/Resources/Prototypes/Entities/Structures/Power/chargers.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/chargers.yml
@@ -222,6 +222,9 @@
           - HitscanBatteryAmmoProvider
           - ProjectileBatteryAmmoProvider
           - Stunbaton
+        blacklist:
+           components:  # Goobstation
+           - BatteryRecharge
 
 - type: entity
   parent: BaseRecharger


### PR DESCRIPTION

## Описание PR
<!-- Что вы изменили? -->
Теперь нельзя использовать настенный зарядник/переносной зарядник для зарядки плазменного резака. Вместо этого используйте плазму.

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->
https://github.com/user-attachments/assets/c31aecea-1cdf-4b9a-a4d1-3671f4a1a450

**Список изменений**
:cl:
- fix: Исправлено: настенный зарядник, переносной зарядник больше не подходят для зарядки плазменного резака.