### PR TITLE
[Maps] Omega prototype hotfix

### DIFF
--- a/Resources/Prototypes/Corvax/Maps/Next/omega.yml
+++ b/Resources/Prototypes/Corvax/Maps/Next/omega.yml
@@ -2,6 +2,8 @@
   id: NextOmega
   mapName: 'Next Omega'
   mapPath: /Maps/Next/next_omega.yml
+  maxRandomOffset: 0
+  randomRotation: false
   minPlayers: 0
   maxPlayers: 25
   stations:


### PR DESCRIPTION
## Описание PR
Убран случайный поворот станции раундстартом

## Почему / Баланс
Случайный поворот станции конфликтовал со спасательными капсулами (в связи с добавлением новой механики поломки гридов), из-за чего в самом центре карты полностью ломалось покрытие, создавая раундстартовую разгерметизацию.

## Ссылка на ветку
[Ветка обсуждения Омеги и её ПРов](https://discord.com/channels/919301044784226385/1325808875588419725)

**Список изменений**
:cl: Aireki
- fix: Исправлена раундстартовая разгерметизация в центре карты, путём удаления случайного поворота у станции.