### PR TITLE
Fix Plant Analyzer

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -130,7 +130,6 @@
     - ServiceStatic
     - PowerCellsStatic
     - ElectronicsStatic
-    - PlantanalyzerStatic
   - type: EmagLatheRecipes
     emagStaticPacks:
     - SecurityAmmoStatic
@@ -211,6 +210,7 @@
     - BluespaceCrystallDynamic
     - AdvancedTreatmentDynamic
     - PlasmaCutter
+    - PlantAnalyzerDynamic
   - type: EmagLatheRecipes
     emagDynamicPacks:
     - SecurityAmmo

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -210,7 +210,7 @@
     - BluespaceCrystallDynamic
     - AdvancedTreatmentDynamic
     - PlasmaCutter
-    - PlantAnalyzerDynamic
+    - PlantAnalyzerDynamic # Corvax Next
   - type: EmagLatheRecipes
     emagDynamicPacks:
     - SecurityAmmo

--- a/Resources/Prototypes/_CorvaxNext/Recipes/Lathes/Packs/botany.yml
+++ b/Resources/Prototypes/_CorvaxNext/Recipes/Lathes/Packs/botany.yml
@@ -1,5 +1,5 @@
 - type: latheRecipePack
-  id: PlantanalyzerStatic
+  id: PlantAnalyzerDynamic
   recipes:
-    - Plantanalyzer
+    - PlantAnalyzer
 


### PR DESCRIPTION
## Описание PR
Исправил ошибку из за которой анализатор растений можно было раундстартом печатать в автолате, а в протолате невозможно даже после соответствующего исследования.

## Почему / Баланс
Анализатор растений является исследуемым предметом в ветке сервиса, возможность печатать его раундстартом в автолате не круто.

## Технические детали
Переименовал PlantanalyzerStatic в PlantAnalyzerDynamic.
Удалил PlantanalyzerStatic из рецептов автолата.
Добавил PlantAnalyzerDynamic в динамические рецепты протолата.
В PlantAnalyzerDynamic заменил рецепт Plantanalyzer на исследуемую в РНД версию PlantAnalyzer.