### PR TITLE
Uplink Rebalance tt

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/TraitorRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/TraitorRuleComponent.cs
@@ -87,5 +87,5 @@ public sealed partial class TraitorRuleComponent : Component
     /// The amount of TC traitors start with.
     /// </summary>
     [DataField]
-    public FixedPoint2 StartingBalance = 20;
+    public FixedPoint2 StartingBalance = 26;
 }

--- a/Content.Server/GameTicking/Rules/Components/TraitorRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/TraitorRuleComponent.cs
@@ -87,5 +87,5 @@ public sealed partial class TraitorRuleComponent : Component
     /// The amount of TC traitors start with.
     /// </summary>
     [DataField]
-    public FixedPoint2 StartingBalance = 26;
+    public FixedPoint2 StartingBalance = 26; //Corvax Balance
 }

--- a/Content.Server/GameTicking/Rules/Components/TraitorRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/TraitorRuleComponent.cs
@@ -87,5 +87,5 @@ public sealed partial class TraitorRuleComponent : Component
     /// The amount of TC traitors start with.
     /// </summary>
     [DataField]
-    public FixedPoint2 StartingBalance = 26; //Corvax Balance
+    public FixedPoint2 StartingBalance = 20;
 }

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -101,9 +101,9 @@
   productEntity: ClothingHandsGlovesNorthStar
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 3 #Corvax price 
+    Telecrystal: 4
   cost:
-    Telecrystal: 6 #Corvax price 
+    Telecrystal: 7 #Corvax price 
   categories:
   - UplinkWeaponry
 
@@ -1668,7 +1668,7 @@
   discountDownTo:
     Telecrystal: 8
   cost:
-    Telecrystal: 12
+    Telecrystal: 14
   categories:
   - UplinkWearables
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -101,9 +101,9 @@
   productEntity: ClothingHandsGlovesNorthStar
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 3 #Corvax price 
   cost:
-    Telecrystal: 6
+    Telecrystal: 6 #Corvax price 
   categories:
   - UplinkWeaponry
 
@@ -116,7 +116,7 @@
   discountDownTo:
     Telecrystal: 3
   cost:
-    Telecrystal: 5
+    Telecrystal: 5 #Corvax price 
   categories:
   - UplinkWeaponry
   conditions:
@@ -359,9 +359,9 @@
   productEntity: ClothingBackpackDuffelSyndicateC4tBundle
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 6
+    Telecrystal: 6 #Corvax price 
   cost:
-    Telecrystal: 10
+    Telecrystal: 10 #Corvax price 
   categories:
   - UplinkExplosives
 
@@ -520,7 +520,7 @@
   icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/SpeedLoaders/Magnum/magnum_speed_loader.rsi, state: icon }
   productEntity: SpeedLoaderMagnumAP
   cost:
-    Telecrystal: 2
+    Telecrystal: 2 #Corvax price 
   categories:
   - UplinkAmmo
 
@@ -651,7 +651,7 @@
   discountDownTo:
     Telecrystal: 2
   cost:
-    Telecrystal: 4
+    Telecrystal: 4 #Corvax price
   categories:
   - UplinkChemicals
 
@@ -753,7 +753,7 @@
   discountDownTo:
     Telecrystal: 2
   cost:
-    Telecrystal: 3
+    Telecrystal: 3 #Corvax price 
   categories:
   - UplinkDeception
 
@@ -859,7 +859,7 @@
   productEntity: ClothingBackpackDuffelSyndicateDecoyKitFilled
   discountCategory: usualDiscounts
   cost:
-    Telecrystal: 2
+    Telecrystal: 2 #Corvax price 
   categories:
   - UplinkDeception
 
@@ -898,7 +898,7 @@
   productEntity: Emag
   discountCategory: veryRareDiscounts
   cost:
-    Telecrystal: 3
+    Telecrystal: 3 #Corvax price 
   categories:
   - UplinkDisruption
 
@@ -1596,7 +1596,7 @@
   productEntity: ClothingBackpackDuffelSyndicateEVABundle
   discountCategory: rareDiscounts
   cost:
-    Telecrystal: 1
+    Telecrystal: 1 #Corvax price 
   categories:
   - UplinkWearables
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -651,7 +651,7 @@
   discountDownTo:
     Telecrystal: 2
   cost:
-    Telecrystal: 5
+    Telecrystal: 4
   categories:
   - UplinkChemicals
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -101,9 +101,9 @@
   productEntity: ClothingHandsGlovesNorthStar
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 4
+    Telecrystal: 3
   cost:
-    Telecrystal: 8
+    Telecrystal: 6
   categories:
   - UplinkWeaponry
 
@@ -116,7 +116,7 @@
   discountDownTo:
     Telecrystal: 3
   cost:
-    Telecrystal: 6
+    Telecrystal: 5
   categories:
   - UplinkWeaponry
   conditions:
@@ -359,9 +359,9 @@
   productEntity: ClothingBackpackDuffelSyndicateC4tBundle
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 8
+    Telecrystal: 6
   cost:
-    Telecrystal: 12 #you're buying bulk so its a 25% discount, so no additional random discount over it
+    Telecrystal: 10
   categories:
   - UplinkExplosives
 
@@ -520,7 +520,7 @@
   icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/SpeedLoaders/Magnum/magnum_speed_loader.rsi, state: icon }
   productEntity: SpeedLoaderMagnumAP
   cost:
-    Telecrystal: 3
+    Telecrystal: 2
   categories:
   - UplinkAmmo
 
@@ -753,7 +753,7 @@
   discountDownTo:
     Telecrystal: 2
   cost:
-    Telecrystal: 5
+    Telecrystal: 3
   categories:
   - UplinkDeception
 
@@ -858,10 +858,8 @@
   icon: { sprite: /Textures/Objects/Tools/Decoys/operative_decoy.rsi, state: folded }
   productEntity: ClothingBackpackDuffelSyndicateDecoyKitFilled
   discountCategory: usualDiscounts
-  discountDownTo:
-    Telecrystal: 3
   cost:
-    Telecrystal: 6
+    Telecrystal: 2
   categories:
   - UplinkDeception
 
@@ -899,10 +897,8 @@
   description: uplink-emag-desc
   productEntity: Emag
   discountCategory: veryRareDiscounts
-  discountDownTo:
-    Telecrystal: 3
   cost:
-    Telecrystal: 5
+    Telecrystal: 3
   categories:
   - UplinkDisruption
 
@@ -1599,10 +1595,8 @@
   icon: { sprite: /Textures/Clothing/OuterClothing/Suits/eva_syndicate.rsi, state: icon }
   productEntity: ClothingBackpackDuffelSyndicateEVABundle
   discountCategory: rareDiscounts
-  discountDownTo:
-    Telecrystal: 1
   cost:
-    Telecrystal: 2
+    Telecrystal: 1
   categories:
   - UplinkWearables
 

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -208,6 +208,7 @@
   id: BaseTraitorRule
   components:
   - type: TraitorRule
+    startingBalance: 26 #Corvax Balance
   # TODO: codewords in yml
   # TODO: uplink in yml
   - type: AntagRandomObjectives


### PR DESCRIPTION
## Описание PR
Добавил предателю ТК и снизил стоимость некоторых товаров в более справедливом их полезности направлении.
## Почему
Чтобы роль предателя стала менее душной и люди могли делать "интересную ответственную игру на антаге", например купить имплант аплинка, чтобы проебать кпк при задержании и, при удачи, сбежать из пермы.
Метоброня на коробку была снята, что сделала её неиспользуемой, ЕМАГ стал одноразовым в полезности, но цена их полезности решила не соответствовать.
На этот раз с меньшей конфликтностью.
**Список изменений**
:cl:
- tweak: баланс предателя 20тк -> 26тк
- tweak: перчатки полярной звезды 8тк -> 7тк
- tweak: спидлоадер .45 бб 3тк -> 2тк
- tweak: набор отключения эл-ва 6тк -> 5тк
- tweak: набор С4 12тк -> 10тк
- tweak: набор ВКД синдиката 2тк -> 1тк
- tweak: боевая аптечка 5тк -> 4тк
- tweak: стелс коробка 5тк -> 3тк
- tweak: набор обманок 6тк -> 2тк
- tweak: ЕМАГ 5тк -> 3тк
- tweak: джагерка 12тк -> 14тк