### PR TITLE
Нерф скороходов

### DIFF
--- a/Content.Shared/_CorvaxNext/StaminaDrain/Components/.StaminaDrainComponent.cs
+++ b/Content.Shared/_CorvaxNext/StaminaDrain/Components/.StaminaDrainComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Clothing.Components;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class StaminaDrainComponent : Component
+{
+    /// <summary>
+    /// Количество урона наносимого стамине в секунду
+    /// </summary>
+    [DataField]
+    public float StaminaPerSecond = 5.0f;
+}

--- a/Content.Shared/_CorvaxNext/StaminaDrain/Components/StaminaDrainComponent.cs
+++ b/Content.Shared/_CorvaxNext/StaminaDrain/Components/StaminaDrainComponent.cs
@@ -1,13 +1,10 @@
 using Robust.Shared.GameStates;
 
-namespace Content.Shared.Clothing.Components;
+namespace Content.Shared._CorvaxNext.StaminaDrain.Components;
 
 [RegisterComponent, NetworkedComponent]
 public sealed partial class StaminaDrainComponent : Component
 {
-    /// <summary>
-    /// Количество урона наносимого стамине в секунду
-    /// </summary>
     [DataField]
     public float StaminaPerSecond = 5.0f;
 }

--- a/Content.Shared/_CorvaxNext/StaminaDrain/Systems/StaminaDrainSystem.cs
+++ b/Content.Shared/_CorvaxNext/StaminaDrain/Systems/StaminaDrainSystem.cs
@@ -5,8 +5,6 @@ using Content.Shared.Inventory;
 using Content.Shared.Item.ItemToggle;
 using Content.Shared.Item.ItemToggle.Components;
 using Robust.Shared.Containers;
-using Robust.Shared.Player;
-using Robust.Shared.Localization;
 using Content.Shared.Popups;
 
 namespace Content.Shared.Clothing.EntitySystems;
@@ -16,10 +14,9 @@ public sealed class StaminaDrainSystem : EntitySystem
     [Dependency] private readonly ItemToggleSystem _toggle = default!;
     [Dependency] private readonly StaminaSystem _stamina = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
-    [Dependency] private readonly ISharedPlayerManager _playerManager = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
 
-    private readonly HashSet<EntityUid> _notified = new();
+    private readonly HashSet<EntityUid> _notifiedWearers = new();
 
     public override void Update(float frameTime)
     {
@@ -31,7 +28,7 @@ public sealed class StaminaDrainSystem : EntitySystem
             if (!toggle.Activated)
             {
                 if (_container.TryGetContainingContainer(uid, out var containerTmp))
-                    _notified.Remove(containerTmp.Owner);
+                    _notifiedWearers.Remove(containerTmp.Owner);
                 continue;
             }
 
@@ -42,11 +39,8 @@ public sealed class StaminaDrainSystem : EntitySystem
             if (!EntityManager.HasComponent<StaminaComponent>(wearer))
                 continue;
 
-            if (!_notified.Contains(wearer))
-            {
-                _notified.Add(wearer);
+            if (_notifiedWearers.Add(wearer))
                 _popup.PopupClient(Loc.GetString("stamina-drain-popup"), wearer);
-            }
 
             _stamina.TakeStaminaDamage(wearer, drain.StaminaPerSecond * frameTime, visual: false);
         }

--- a/Content.Shared/_CorvaxNext/StaminaDrain/Systems/StaminaDrainSystem.cs
+++ b/Content.Shared/_CorvaxNext/StaminaDrain/Systems/StaminaDrainSystem.cs
@@ -1,0 +1,54 @@
+using Content.Shared.Clothing.Components;
+using Content.Shared.Damage.Components;
+using Content.Shared.Damage.Systems;
+using Content.Shared.Inventory;
+using Content.Shared.Item.ItemToggle;
+using Content.Shared.Item.ItemToggle.Components;
+using Robust.Shared.Containers;
+using Robust.Shared.Player;
+using Robust.Shared.Localization;
+using Content.Shared.Popups;
+
+namespace Content.Shared.Clothing.EntitySystems;
+
+public sealed class StaminaDrainSystem : EntitySystem
+{
+    [Dependency] private readonly ItemToggleSystem _toggle = default!;
+    [Dependency] private readonly StaminaSystem _stamina = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
+    [Dependency] private readonly ISharedPlayerManager _playerManager = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    private readonly HashSet<EntityUid> _notified = new();
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<StaminaDrainComponent, ItemToggleComponent>();
+        while (query.MoveNext(out var uid, out var drain, out var toggle))
+        {
+            if (!toggle.Activated)
+            {
+                if (_container.TryGetContainingContainer(uid, out var containerTmp))
+                    _notified.Remove(containerTmp.Owner);
+                continue;
+            }
+
+            if (!_container.TryGetContainingContainer(uid, out var container))
+                continue;
+
+            var wearer = container.Owner;
+            if (!EntityManager.HasComponent<StaminaComponent>(wearer))
+                continue;
+
+            if (!_notified.Contains(wearer))
+            {
+                _notified.Add(wearer);
+                _popup.PopupClient(Loc.GetString("stamina-drain-popup"), wearer);
+            }
+
+            _stamina.TakeStaminaDamage(wearer, drain.StaminaPerSecond * frameTime, visual: false);
+        }
+    }
+}

--- a/Content.Shared/_CorvaxNext/StaminaDrain/Systems/StaminaDrainSystem.cs
+++ b/Content.Shared/_CorvaxNext/StaminaDrain/Systems/StaminaDrainSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._CorvaxNext.StaminaDrain.Components;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Systems;
@@ -7,7 +8,7 @@ using Content.Shared.Item.ItemToggle.Components;
 using Robust.Shared.Containers;
 using Content.Shared.Popups;
 
-namespace Content.Shared.Clothing.EntitySystems;
+namespace Content.Shared._CorvaxNext.StaminaDrain.Systems;
 
 public sealed class StaminaDrainSystem : EntitySystem
 {

--- a/Resources/Locale/ru-RU/_corvaxnext/staminadrain/stamina-drain-component.ftl
+++ b/Resources/Locale/ru-RU/_corvaxnext/staminadrain/stamina-drain-component.ftl
@@ -1,2 +1,1 @@
-popup-system-repeated-popup-stacking-wrap = { $popup-message } x{ $count }
 stamina-drain-popup = Вы чувствуете усталость в ногах из-за повышения скорости

--- a/Resources/Locale/ru-RU/_corvaxnext/staminadrain/stamina-drain-component.ftl
+++ b/Resources/Locale/ru-RU/_corvaxnext/staminadrain/stamina-drain-component.ftl
@@ -1,0 +1,2 @@
+popup-system-repeated-popup-stacking-wrap = { $popup-message } x{ $count }
+stamina-drain-popup = Вы чувствуете усталость в ногах из-за повышения скорости

--- a/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
@@ -154,6 +154,7 @@
         name: power-cell-slot-component-slot-name-default
   - type: Tag
     tags: []
+  - type: StaminaDrain # CorvaxNext
 
 - type: entity
   id: ActionToggleSpeedBoots


### PR DESCRIPTION
## Описание PR
В прототип скороходов добавлен компонент `StaminaDrain`
При включении скороходов игрок получает сообщение и компонент срабатывает, нанося 5 урона стамине в секунду

## Почему / Баланс
Через 10 секунд после включения скороходов пользователь замедляется (получает 50 урона стамине), после 20 секунд активного использования пользователь падает в стамина крит (100 урона по стамине). Скороходы сломаны из-за возможности изучения двух т3 веток в РНД. В итоге мы имеем антажек (или всю станцию), что ближе к 40 минуте бегают в скороходах с микрореакторными батареями, с этим изменением скороходы не получится использовать вечно и нужно будет контролировать их включение и выключение

## Ссылка на ветку
https://discord.com/channels/919301044784226385/1371106360447729684

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
Добавлен компонент и система для него 
Компонент указывает сколько урона по стамине будет наносится при включении 
Система находит того кто носит и скороходы и когда он их активирует выводит одноразовое сообщение и каждую секунду уменьшает выносливость

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
:cl:
+ tweak: При включении скороходы потребляют стамину
