### PR TITLE
Laser guns rebalance

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -256,6 +256,13 @@
   components:
   - type: StaticPrice
     price: 420
+  # Corvax-Next-LaserGunsRebalancea-start
+  - type: Battery
+    maxCharge: 1875
+    startingCharge: 1875
+  - type: Gun
+    fireRate: 2.25
+  # Corvax-Next-LaserGunsRebalancea-end
   - type: HitscanBatteryAmmoProvider
     proto: RedLaser
     fireCost: 62.5
@@ -390,6 +397,11 @@
     fireRate: 1.5
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
+  # Corvax-Next-LaserGunsRebalancea-start
+  - type: Battery
+    maxCharge: 1500
+    startingCharge: 1500
+  # Corvax-Next-LaserGunsRebalancea-end
     requiresSkill: true # Corvax-Next-Skills
   - type: HitscanBatteryAmmoProvider
     proto: RedHeavyLaser

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -397,12 +397,12 @@
     fireRate: 1.5
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
+    requiresSkill: true # Corvax-Next-Skills
   # Corvax-Next-LaserGunsRebalancea-start
   - type: Battery
     maxCharge: 1500
     startingCharge: 1500
   # Corvax-Next-LaserGunsRebalancea-end
-    requiresSkill: true # Corvax-Next-Skills
   - type: HitscanBatteryAmmoProvider
     proto: RedHeavyLaser
     fireCost: 100


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
### Лазерный карабин
- Емкость магазина увеличена с 16-ти выстрелов до 30-ти.
- Скорострельность увеличена с 2 до 2.25.
### Лазерная пушка
- Емкость магазина увеличена с 10-ти выстрелов до 15-ти.

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
Ну, теперь это можно хотя бы назвать оружием. Повышена именно ёмкость батареи, благодаря чему скорость зарядки до прежних значений останется той же.

## Ссылка на ветку
<!-- Необязательный пункт. Удалите раздел целиком, если он пуст.
Ссылка на ветку обсуждения ПРа в Discord.
Следите, чтобы информация в первом сообщении была актуальной. -->
https://discord.com/channels/919301044784226385/1374036263270748312

**Список изменений**
:cl: Ko4erga
- tweak: Улучшены характеристики лазерного карабина и лазерной пушки.
