### PR TITLE
StationAiVision

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -351,7 +351,7 @@
       Unsexed: UnisexSiliconSyndicate
   - type: PointLight
     color: "#dd200b"
-  - type: StationAiVision #Corvax-Next
+  - type: StationAiVision # Corvax-Next
     range: -1
 
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -253,7 +253,7 @@
   - type: TTS # Corvax-TTS
     voice: TrainingRobot
   - type: Targeting # Corvax-Next-Surgery
-  - type: StationAiVision
+  - type: StationAiVision # Corvax-Next
   - type: Skills # Corvax-Next-Skills
     skills:
     - ShuttleControl
@@ -351,7 +351,7 @@
       Unsexed: UnisexSiliconSyndicate
   - type: PointLight
     color: "#dd200b"
-  - type: StationAiVision
+  - type: StationAiVision #Corvax-Next
     range: -1
 
 - type: entity
@@ -373,5 +373,5 @@
   - type: IonStormTarget
     chance: 1
   - type: ShowJobIcons
-  - type: StationAiVision
+  - type: StationAiVision # Corvax-Next
     range: 2

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -253,6 +253,7 @@
   - type: TTS # Corvax-TTS
     voice: TrainingRobot
   - type: Targeting # Corvax-Next-Surgery
+  - type: StationAiVision
   - type: Skills # Corvax-Next-Skills
     skills:
     - ShuttleControl

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -351,6 +351,8 @@
       Unsexed: UnisexSiliconSyndicate
   - type: PointLight
     color: "#dd200b"
+  - type: StationAiVision
+    range: -1
 
 - type: entity
   id: BaseBorgChassisDerelict
@@ -371,3 +373,5 @@
   - type: IonStormTarget
     chance: 1
   - type: ShowJobIcons
+  - type: StationAiVision
+    range: 2


### PR DESCRIPTION
## Описание PR
ЦИИ теперь видит, что происходит вокруг боргов (за исключением боргов синдиката). Заброшенные борги показывают лишь 2 тайла вокруг себя.

## Почему / Баланс
Это логично, тем более, когда в игру добавлена плата Бориса. ЦИИ сможет лучше коммуницировать с боргами, частично получит доступ к техпомещениям.

## Технические детали
Один компонент в прототип боргов (StationAiVision , расстояние не затронуто)

**Список изменений**
:cl:
- add: ЦИИ видит, что делают борги.
