### PR TITLE
Say NO WIZARD!

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -41,7 +41,7 @@
     - id: DerelictCyborgSpawn
    # - id: ZombieOutbreak
     - id: BlobSpawn #Goobstation - Blob
-   # - id: WizardSpawn
+   # - id: WizardSpawn # next-NO-WIZARD
 
 - type: entity
   id: BaseStationEvent

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -41,7 +41,7 @@
     - id: DerelictCyborgSpawn
    # - id: ZombieOutbreak
     - id: BlobSpawn #Goobstation - Blob
-    - id: WizardSpawn
+   # - id: WizardSpawn
 
 - type: entity
   id: BaseStationEvent
@@ -311,9 +311,9 @@
   - type: StationEvent
     weight: 1 # rare
     duration: 1
-    earliestStart: 30
+    earliestStart: 60
     reoccurrenceDelay: 60
-    minimumPlayers: 10
+    minimumPlayers: 45
   - type: AntagSelection
     agentName: wizard-round-end-name
     definitions:

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -41,7 +41,7 @@
     - id: DerelictCyborgSpawn
    # - id: ZombieOutbreak
     - id: BlobSpawn #Goobstation - Blob
-   # - id: WizardSpawn # next-NO-WIZARD
+   # - id: WizardSpawn # Corvax-NO-WIZARD
 
 - type: entity
   id: BaseStationEvent

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -311,9 +311,11 @@
   - type: StationEvent
     weight: 1 # rare
     duration: 1
-    earliestStart: 60
+    # Crovax-more-people-for-wizard-start
+    earliestStart: 60 
     reoccurrenceDelay: 60
     minimumPlayers: 45
+    # Corvax-more-people-for-wizard-end
   - type: AntagSelection
     agentName: wizard-round-end-name
     definitions:

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -24,8 +24,8 @@
       prob: 0.5
     - id: Heretic # goob edit
       prob: 0.2
-    - id: SubWizard
-      prob: 0.05
+    #- id: SubWizard
+    #  prob: 0.05
 
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -331,7 +331,7 @@
   id: Wizard
   components:
   - type: GameRule
-    minPlayers: 10
+    minPlayers: 45
   - type: AntagSelection
     agentName: wizard-round-end-name
     selectionTime: PrePlayerSpawn

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -24,7 +24,7 @@
       prob: 0.5
     - id: Heretic # goob edit
       prob: 0.2
-    #- id: SubWizard
+    #- id: SubWizard #Corvax-NO-WIZARD
     #  prob: 0.05
 
 - type: entity
@@ -331,7 +331,7 @@
   id: Wizard
   components:
   - type: GameRule
-    minPlayers: 45
+    minPlayers: 45 # Corvax-more-people-for-wizard
   - type: AntagSelection
     agentName: wizard-round-end-name
     selectionTime: PrePlayerSpawn

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -8,4 +8,4 @@
     Revolutionary: 0.06
     Heretic: 0.15
     Blob: 0.05
-    Wizard: 0.05 # Why not, should probably be lower
+#    Wizard: 0.05 # Why not, should probably be lower

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -8,4 +8,4 @@
     Revolutionary: 0.06
     Heretic: 0.15
     Blob: 0.05
-#    Wizard: 0.05 # Why not, should probably be lower
+#    Wizard: 0.05 # Corvax-NO-WIZARD #Why not, should probably be lower


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Удалена возможность выпадения самостоятельно мага + на будущее увеличен минимальный его порог.

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
Потому что этот ебланоид щас такую хуйню может творить, так что лучше пусть будет появляться только под наблюдением администрации.

## Ссылка на ветку
<!-- Необязательный пункт. Удалите раздел целиком, если он пуст.
Ссылка на ветку обсуждения ПРа в Discord.
Следите, чтобы информация в первом сообщении была актуальной. -->
Закрытые чаты :cat_xdd:

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
По факту - просто комиты/изменение параметров

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
<!--
:cl:
- remove: Удалена возможность появления мага в раунде.
-->
:cl:
- remove: Удалена возможность появления мага в раунде.