### PR TITLE
Wizard gamerule rebalance

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -313,7 +313,7 @@
     duration: 1
     earliestStart: 30
     reoccurrenceDelay: 60
-    minimumPlayers: 10
+    minimumPlayers: 40 #Corvax-Next wizard-gamerule-rebalance
   - type: AntagSelection
     agentName: wizard-round-end-name
     definitions:

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -331,7 +331,7 @@
   id: Wizard
   components:
   - type: GameRule
-    minPlayers: 10
+    minPlayers: 25 #Corvax-Next wizard-gamerule-rebalance
   - type: AntagSelection
     agentName: wizard-round-end-name
     selectionTime: PrePlayerSpawn


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Минимальное количество игроков для спавна мидраунд мага 10 -> 40
Минимальное количество игроков для режима мага 10 -> 25
## Почему баланс?
Распинаться о том, почему маг немного ебнутый в текущих реалиях без правил антаг желания нету. Просто убирает его возможность спавна при 10-ти землекопах.