### PR TITLE
Remove damage from zombies to initials

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -252,6 +252,12 @@ namespace Content.Server.Zombies
                 if (!TryComp<MobStateComponent>(entity, out var mobState))
                     continue;
 
+                if (HasComp<InitialInfectedComponent>(entity)) // Corvax-Next-NoFriendlyFireToInitials
+                {
+                    args.BonusDamage = -args.BaseDamage;
+                    continue;
+                }
+
                 if (HasComp<ZombieComponent>(entity))
                 {
                     args.BonusDamage = -args.BaseDamage;


### PR DESCRIPTION
## Описание PR
Убран дамаг зомбучек по нулевым.

## Почему / Баланс
Ограничение игромеханическb, вместо правил, уменьшение квоты по банам за П.6.

## Ссылка на ветку
https://discord.com/channels/919301044784226385/1380915375742648460
