### PR TITLE
Disable auto ImplicitRoof

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.cs
@@ -121,7 +121,7 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
             return;
 
         EnsureComp<ShuttleComponent>(ev.EntityUid);
-        EnsureComp<ImplicitRoofComponent>(ev.EntityUid);
+        // EnsureComp<ImplicitRoofComponent>(ev.EntityUid); Corvax-Next-DeleteAutoImplicitRoof
     }
 
     private void OnShuttleStartup(EntityUid uid, ShuttleComponent component, ComponentStartup args)


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Отключил авто добавление компонента ImplicitRoof на гриды. Это руинит все ивентовые карты и островные станции, так как накрывает весь грид крышей. пизедц
