### PR TITLE
Minerssalve balance

### DIFF
--- a/Resources/Prototypes/_Lavaland/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Lavaland/Reagents/medicine.yml
@@ -48,8 +48,15 @@
           min: 21
         damage:
           types:
-            Poison: 15
+            Poison: 14
             Cold: 15
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 41
+        damage:
+          types:
+            Poison: 0.5
       - !type:Jitter
       - !type:PopupMessage
         type: Local

--- a/Resources/Prototypes/_Lavaland/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Lavaland/Reagents/medicine.yml
@@ -40,6 +40,10 @@
           worksOnLavaland: true
       - !type:HealthChange
         conditions:
+        - !type:PressureThreshold
+          min: 0
+          max: 50
+          worksOnLavaland: true
         - !type:ReagentThreshold
           min: 21
         damage:


### PR DESCRIPTION
## Описание PR
Исправлен баланс медипена и реагента

## Почему / Баланс
Основной дамаг (15u ядами и 15u холодом) теперь наносятся только на лаваленде. Был добавлен урон в случае нахождения вне лаваленда при 41u утилеславина в крови (>2 медипенов). Урон вне лавы составляет 0.5 ядами (10u за медипен).

Чтоб убить условного человека вне лаваленда потребуется вкинуть ему около 12 медипенов.