### PR TITLE
Chemical Glasses can analyze smoke and foam.

### DIFF
--- a/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
+++ b/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
@@ -31,8 +31,8 @@
       solutionArea:
         maxVol: 600
         canReact: false
-  - type: ExaminableSolution
-    solution: solutionArea
+  - type: ExaminableSolution # Corvax-Next 
+    solution: solutionArea # Corvax-Next
 
 - type: entity
   parent: BaseFoam


### PR DESCRIPTION
## Описание PR
 Добавлена возможность просматривать состав пены и дыма с помощью визора химического анализа.

## Почему / Баланс
 Нелогично что химик не может с помощью своих очков узнать состав пены, которая тоже жидкость, только вспененная. Точно такая же ситуация и с дымом, в которых обычно находятся химикаты.

