### PR TITLE
Lightning bolt smite

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.cs
@@ -84,6 +84,8 @@ namespace Content.Server.Administration.Systems
             AddSmiteVerbs(ev);
             AddTricksVerbs(ev);
             AddAntagVerbs(ev);
+
+            AddCorvaxNextSmites(ev); // CorvaxNext-Smites
         }
 
         private void AddAdminVerbs(GetVerbsEvent<Verb> args)

--- a/Content.Server/_CorvaxNext/Administration/Systems/AdminVerbSystem.Smites.cs
+++ b/Content.Server/_CorvaxNext/Administration/Systems/AdminVerbSystem.Smites.cs
@@ -1,0 +1,51 @@
+using Content.Shared.Administration;
+using Content.Shared.Database;
+using Content.Shared.StatusEffect;
+using Content.Shared.Verbs;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Player;
+using Robust.Shared.Utility;
+
+namespace Content.Server.Administration.Systems;
+
+public sealed partial class AdminVerbSystem
+{
+    [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
+    private void AddCorvaxNextSmites(GetVerbsEvent<Verb> args)
+    {
+        if (!EntityManager.TryGetComponent(args.User, out ActorComponent? actor))
+            return;
+
+        var player = actor.PlayerSession;
+
+        if (!_adminManager.HasAdminFlag(player, AdminFlags.Fun))
+            return;
+
+        if (HasComp<MapComponent>(args.Target) || HasComp<MapGridComponent>(args.Target))
+            return;
+
+        if (TryComp<StatusEffectsComponent>(args.Target, out var statusEffectsComp))
+        {
+            var lightningBoltName = Loc.GetString("admin-smite-lightning-bolt-name").ToLowerInvariant();
+            Verb lightningBolt = new()
+            {
+                Text = lightningBoltName,
+                Category = VerbCategory.Smite,
+                Icon = new SpriteSpecifier.Rsi(new("/Textures/Effects/lightning.rsi"), "lightning_2"),
+                Act = () =>
+                {
+                    EntityManager.SpawnAtPosition("EffectFlashLightningBolt", _transformSystem.GetMoverCoordinates(args.Target));
+                    _audioSystem.PlayPvs(new SoundPathSpecifier("/Audio/Effects/tesla_collapse.ogg"), args.Target, AudioParams.Default.WithVariation((float?)0.25));
+
+                    _electrocutionSystem.TryDoElectrocution(args.Target, null, 35, TimeSpan.FromSeconds(3), refresh: true, ignoreInsulation: true);
+                },
+                Impact = LogImpact.Extreme,
+                Message = string.Join(": ", lightningBoltName, Loc.GetString("admin-smite-lightning-bolt-description"))
+            };
+            args.Verbs.Add(lightningBolt);
+        }
+    }
+}
+

--- a/Resources/Locale/en-US/_corvaxnext/administration/smites.ftl
+++ b/Resources/Locale/en-US/_corvaxnext/administration/smites.ftl
@@ -1,0 +1,2 @@
+admin-smite-lightning-bolt-name = Strike with lightning
+admin-smite-lightning-bolt-description = Strikes the target with a large bolt of lightning. YOU SHOULD LOVE YOURSELF... NOW!

--- a/Resources/Locale/ru-RU/_corvaxnext/administration/smites.ftl
+++ b/Resources/Locale/ru-RU/_corvaxnext/administration/smites.ftl
@@ -1,0 +1,2 @@
+admin-smite-lightning-bolt-name = Удар молнией
+admin-smite-lightning-bolt-description = Ударяет цель большим зарядом молнии. ТЫ ДОЛЖЕН ЛЮБИТЬ СЕБЯ... СЕЙЧАС ЖЕ!

--- a/Resources/Prototypes/_CorvaxNext/Entities/Effects/lightning.yml
+++ b/Resources/Prototypes/_CorvaxNext/Entities/Effects/lightning.yml
@@ -1,0 +1,10 @@
+- type: entity
+  id: EffectFlashLightningBolt
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: PointLight
+    radius: 10.5
+    energy: 15
+    color: "#fcfcf6"
+  - type: TimedDespawn
+    lifetime: 0.4


### PR DESCRIPTION
## Описание PR
Добавлена новая божья кара - удар молнии. Наносит 35 урона электричеством, оглушает цель на 3 секунды.

## Почему / Баланс
Удобная штука чтобы карать серунчиков в чат или двухклятых ЕРПешеров. По сравнению с остальными карами, эта выглядит более менее РПшнее и не смертельнее, чем те, что в стиле "превратить в обезьяну", "обескровить", "кикнуть пингом".

## Медиа
https://github.com/user-attachments/assets/febad511-057a-4de3-98cf-339afb6e9380