### PR TITLE
HealthScanner now can analyze chemical reagents in creatures

### DIFF
--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml
@@ -204,6 +204,8 @@
                     <Label Name="TemperatureLabel"/>
                     <Label Text="{Loc 'health-analyzer-window-entity-blood-level-text'}"/>
                     <Label Name="BloodLabel"/>
+                    <Label Text="{Loc 'health-analyzer-window-entity-reagents-text'}"/> <!-- CorvaxNext: healthAnalyzerupdate -->
+                    <Label Name="ChemicalsLabel"/> <!-- CorvaxNext: healthAnalyzerupdate -->
                     <Label Text="{Loc 'health-analyzer-window-entity-damage-total-text'}"/>
                     <Label Name="DamageLabel"/>
                 </GridContainer>

--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml.cs
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml.cs
@@ -26,6 +26,8 @@ using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
+using Content.Shared.Chemistry.Components.SolutionManager; // CorvaxNext: healthAnalyzerupdate
+using Content.Shared.Chemistry.EntitySystems; // CorvaxNext: healthAnalyzerupdate
 
 namespace Content.Client.HealthAnalyzer.UI
 {
@@ -171,7 +173,11 @@ namespace Content.Client.HealthAnalyzer.UI
             BloodLabel.Text = !float.IsNaN(msg.BloodLevel)
                 ? $"{msg.BloodLevel * 100:F1} %"
                 : Loc.GetString("health-analyzer-window-entity-unknown-value-text");
-
+                // Start-_CorvaxNext: healthAnalyzerupdate
+            ChemicalsLabel.Text = msg.Chemicals != null && msg.Chemicals.Count > 0
+                ? string.Join("\n", msg.Chemicals.Select(c => $"{c.Key}: {c.Value.Float():F1}u"))
+                : Loc.GetString("health-analyzer-window-entity-no-chemicals-text");
+               // End-_CorvaxNext: healthAnalyzerupdate
             StatusLabel.Text =
                 _entityManager.TryGetComponent<MobStateComponent>(_target.Value, out var mobStateComponent)
                     ? GetStatus(mobStateComponent.CurrentState)

--- a/Content.Shared/MedicalScanner/HealthAnalyzerScannedUserMessage.cs
+++ b/Content.Shared/MedicalScanner/HealthAnalyzerScannedUserMessage.cs
@@ -1,6 +1,7 @@
 using Content.Shared._CorvaxNext.Targeting;
 using Content.Shared.Body.Components;
 using Robust.Shared.Serialization;
+using Content.Shared.FixedPoint; // CorvaxNext: healthAnalyzerupdate
 
 namespace Content.Shared.MedicalScanner;
 
@@ -18,8 +19,9 @@ public sealed class HealthAnalyzerScannedUserMessage : BoundUserInterfaceMessage
     public bool? Unrevivable;
     public Dictionary<TargetBodyPart, TargetIntegrity>? Body; // CorvaxNext: surgery
     public NetEntity? Part; // CorvaxNext: surgery
+    public readonly Dictionary<string, FixedPoint2>? Chemicals; // CorvaxNext: healthAnalyzerupdate
 
-    public HealthAnalyzerScannedUserMessage(NetEntity? targetEntity, float temperature, float bloodLevel, bool? scanMode, bool? bleeding, bool? unrevivable, Dictionary<TargetBodyPart, TargetIntegrity>? body, NetEntity? part = null)
+    public HealthAnalyzerScannedUserMessage(NetEntity? targetEntity, float temperature, float bloodLevel, bool? scanMode, bool? bleeding, bool? unrevivable, Dictionary<TargetBodyPart, TargetIntegrity>? body, NetEntity? part = null, Dictionary<string, FixedPoint2>? сhemicals = null) // ,Dictionary<string, FixedPoint2>? chemicals = null - CorvaxNext
     {
         TargetEntity = targetEntity;
         Temperature = temperature;
@@ -29,6 +31,7 @@ public sealed class HealthAnalyzerScannedUserMessage : BoundUserInterfaceMessage
         Unrevivable = unrevivable;
         Body = body; // CorvaxNext: surgery
         Part = part; // CorvaxNext: surgery
+        Chemicals = сhemicals; // CorvaxNext: healthAnalyzerupdate
     }
 }
 

--- a/Resources/Locale/ru-RU/medical/components/health-analyzer-component.ftl
+++ b/Resources/Locale/ru-RU/medical/components/health-analyzer-component.ftl
@@ -17,3 +17,5 @@ health-analyzer-window-scan-mode-text = Режим сканирования:
 health-analyzer-window-scan-mode-active = АКТИВЕН
 health-analyzer-window-scan-mode-inactive = НЕАКТИВЕН
 health-analyzer-popup-scan-target = { CAPITALIZE($user) } пытается просканировать вас!
+health-analyzer-window-entity-reagents-text = Химикаты в крови:  
+health-analyzer-window-entity-no-chemicals-text = Отсутствуют


### PR DESCRIPTION

## Описание PR
Теперь в медицинском сканнере пишется информация о том, какие химикаты находятся в существе.

## Почему / Баланс
Это очень удобно. получить передоз в меде станет сложнее. Инфу о том, какое очередное пойло выпил дворф и чуть не здох будет полезно. 


## Технические детали
 Все добавления и изменения я пометил комментариями.


## Медиа
https://github.com/user-attachments/assets/620c8d8e-b28a-4b43-8663-188523ee26d8






:cl: HolyYogurt
- add: медицинский сканнер  теперь может анализировать химические реагенты в существах
