### PR TITLE
Cyborgs can repair themself now

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -105,7 +105,8 @@
   - type: ZombieImmune
   - type: Repairable
     doAfterDelay: 10
-    allowSelfRepair: false
+    allowSelfRepair: true # Corvax-Next from false to true
+    selfRepairPenalty: 4.5 # Corvax-Next-SelfRepairable
   - type: BorgChassis
   - type: LockingWhitelist
     blacklist:

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -106,7 +106,7 @@
   - type: Repairable
     doAfterDelay: 10
     allowSelfRepair: true # Corvax-Next from false to true
-    selfRepairPenalty: 4.5 # Corvax-Next-SelfRepairable
+    selfRepairPenalty: 6 # Corvax-Next-SelfRepairable
   - type: BorgChassis
   - type: LockingWhitelist
     blacklist:


### PR DESCRIPTION
## Описание PR
Киборги могут чинить самих себя. Увеличено время самопочинки до 60 секунд.

## Почему / Баланс
Не всегда у киборга есть возможность попасть до людей с сварочной маской и сваркой, по сути это только учёные и инженеры, особенно, если киборг занимается автономными задачами в космосе. Если типу не впадлу стоять неподвижно минуту то почему бы и нет