### PR TITLE
Restrict miners to claim points on lavaland

### DIFF
--- a/Content.Server/_DV/Salvage/Systems/ClaimPointsRestrictionSystem.cs
+++ b/Content.Server/_DV/Salvage/Systems/ClaimPointsRestrictionSystem.cs
@@ -1,0 +1,46 @@
+using Content.Shared._DV.Salvage.Components;
+using Content.Shared._DV.Salvage;
+using Content.Shared._DV.Salvage.Systems;
+using Robust.Shared.Audio;
+using Content.Shared.Popups;
+using Robust.Shared.Audio.Systems;
+using Content.Shared.Lathe;
+using Content.Server._Lavaland.Procedural.Components;
+
+namespace Content.Server._DV.Salvage.Systems;
+
+public sealed class ClaimPointsRestrictionSystem : EntitySystem
+{
+    [Dependency] private readonly MiningPointsSystem _points = default!;
+    [Dependency] private readonly IEntityManager _entManager = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        Subs.BuiEvents<MiningPointsLatheComponent>(LatheUiKey.Key, subs =>
+        {
+            subs.Event<LatheClaimMiningPointsMessage>(OnClaimMiningPoints);
+        });
+    }
+    private void OnClaimMiningPoints(Entity<MiningPointsLatheComponent> ent, ref LatheClaimMiningPointsMessage args)
+    {
+        var user = args.Actor;
+
+        if (!(_points.TryFindIdCard(user) is { } dest))
+            return;
+
+        if (!ent.Comp.WorksOnLavaland && _entManager.TryGetComponent<TransformComponent>(ent, out var transform) && HasComp<LavalandMapComponent>(transform.MapUid))
+        {
+            _audio.PlayPvs(new SoundPathSpecifier("/Audio/Machines/custom_deny.ogg"), ent);
+            _popup.PopupEntity(Loc.GetString("lavaland-claim-points-restriction"), ent);
+
+            return;
+        }
+
+        _points.TransferAll(ent.Owner, dest);
+    }
+}
+

--- a/Content.Shared/_DV/Salvage/Components/MiningPointsLatheComponent.cs
+++ b/Content.Shared/_DV/Salvage/Components/MiningPointsLatheComponent.cs
@@ -6,4 +6,11 @@ namespace Content.Shared._DV.Salvage.Components;
 /// Adds points to <see cref="MiningPointsComponent"/> when making a recipe that has miningPoints set.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
-public sealed partial class MiningPointsLatheComponent : Component;
+public sealed partial class MiningPointsLatheComponent : Component
+{
+    /// <summary>
+    /// Can points be claimed on lavaland
+    /// </summary>
+    [DataField]
+    public bool WorksOnLavaland = false;
+}

--- a/Content.Shared/_DV/Salvage/Systems/MiningPointsSystem.cs
+++ b/Content.Shared/_DV/Salvage/Systems/MiningPointsSystem.cs
@@ -24,10 +24,6 @@ public sealed class MiningPointsSystem : EntitySystem
         _query = GetEntityQuery<MiningPointsComponent>();
 
         SubscribeLocalEvent<MiningPointsLatheComponent, MaterialEntityInsertedEvent>(OnMaterialEntityInserted);
-        Subs.BuiEvents<MiningPointsLatheComponent>(LatheUiKey.Key, subs =>
-        {
-            subs.Event<LatheClaimMiningPointsMessage>(OnClaimMiningPoints);
-        });
     }
 
     #region Event Handlers
@@ -41,13 +37,6 @@ public sealed class MiningPointsSystem : EntitySystem
         var points = unclaimedOre.MiningPoints * args.Count;
         if (points > 0)
             AddPoints(ent.Owner, (uint) points);
-    }
-
-    private void OnClaimMiningPoints(Entity<MiningPointsLatheComponent> ent, ref LatheClaimMiningPointsMessage args)
-    {
-        var user = args.Actor;
-        if (TryFindIdCard(user) is {} dest)
-            TransferAll(ent.Owner, dest);
     }
 
     #endregion

--- a/Resources/Locale/ru-RU/_Lavaland/lathe/ui/lathe-menu.ftl
+++ b/Resources/Locale/ru-RU/_Lavaland/lathe/ui/lathe-menu.ftl
@@ -1,2 +1,4 @@
 lathe-menu-mining-points = Шахтёрские очки: {$points}
 lathe-menu-mining-points-claim-button = Забрать очки
+
+lavaland-claim-points-restriction = Энергетическая поле планеты не даёт возможность вывести очки!


### PR DESCRIPTION
## Описание PR
Добавлен игромеханический запрет на вывод очков на лаваленде. Перерабатывать руду всё ещё можно будет, но выводить нет. Запрет можно убрать, поставив галочку на параметре `WorksOnLavaland` в перерабе.

## Почему / Баланс
Банальное мудачество и игра ради себя любимого никому не нравится. Основная задача утилей - пополнять станцию материалами, а не дрочка ради поинтов. 
