### PR TITLE
Buff xenomorph

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -76,9 +76,10 @@
      collection: AlienClaw
     animation: WeaponArcBite
     damage:
+      types:
+       Structural: 20 # Corvax-Next
       groups:
-        Brute: 6
-        Structural: 10 # Corvax-Next
+        Brute: 10
   - type: DamageStateVisuals
     rotate: true
     states:


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Увеличено здоровье и урон у:
Бурильщик:
50 хп -> 90 хп
К 6 механ урону добавилось 20 структурного

Преторианец:
100 хп -> 200 хп
Было 6 механ урона стало 20 механ урона.

Королева:
Было 12 механ урона стало 25 механ урона.

Разрушитель: 
100 хп -> 200 хп
Было 10 механ урона стало 15 механ урона

Плевальщик:
50 хп -> 70 хп

Ксеноморфы научились перетаскивать вещи.

## Почему / Баланс
На данный момент ксеноморфы бесполезны, даже толпами.. Количество ХП и урон (меньше чем у кухонного ножа) делают ксеносов слишком слабыми, как для экспедиций так и для прочих сражений.
Огромная королева убивает человека за 9 укусов. Это довольно странно, учитывая её размеры. 
