### PR TITLE
Tinted windows

### DIFF
--- a/Content.Client/_CorvaxNext/TintedWindow/TintedWindowSystem.cs
+++ b/Content.Client/_CorvaxNext/TintedWindow/TintedWindowSystem.cs
@@ -1,0 +1,32 @@
+using Content.Shared._CorvaxNext.TintedWindow;
+using Robust.Client.Player;
+
+namespace Content.Client._CorvaxNext.TintedWindow;
+
+public sealed class TintedWindowSystem : EntitySystem
+{
+    [Dependency] private readonly IPlayerManager _player = default!;
+    [Dependency] private readonly SharedTransformSystem _xform = default!;
+    [Dependency] private readonly OccluderSystem _occluder = default!;
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (_player.LocalEntity is null)
+            return;
+
+        if (TryComp<EyeComponent>(_player.LocalEntity, out var eye) && !eye.DrawFov)
+            return;
+
+        var query = EntityQueryEnumerator<TintedWindowComponent, OccluderComponent>();
+
+        while (query.MoveNext(out var uid, out var window, out var occluder))
+        {
+            var angle = Angle.FromWorldVec(_xform.GetWorldPosition(_player.LocalEntity.Value) - _xform.GetWorldPosition(uid));
+            var angleDelta = (_xform.GetWorldRotation(uid) - angle).Reduced().FlipPositive();
+            var showOccluder = angleDelta < window.Arc / 2 || Math.Tau - angleDelta < window.Arc / 2;
+            _occluder.SetEnabled(uid, showOccluder, occluder);
+        }
+    }
+}

--- a/Content.Shared/_CorvaxNext/TintedWindow/TintedWindowComponent.cs
+++ b/Content.Shared/_CorvaxNext/TintedWindow/TintedWindowComponent.cs
@@ -1,0 +1,8 @@
+namespace Content.Shared._CorvaxNext.TintedWindow;
+
+[RegisterComponent, AutoGenerateComponentState]
+public sealed partial class TintedWindowComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public Angle Arc = 120;
+}

--- a/Resources/Locale/ru-RU/_corvaxnext/entities/structures/windows/windows.ftl
+++ b/Resources/Locale/ru-RU/_corvaxnext/entities/structures/windows/windows.ftl
@@ -1,0 +1,2 @@
+ent-WindowTintedDirectional = направленное тонированное окно
+    .desc = Смотри не заляпай.

--- a/Resources/Locale/ru-RU/_corvaxnext/entities/structures/windows/windows.ftl
+++ b/Resources/Locale/ru-RU/_corvaxnext/entities/structures/windows/windows.ftl
@@ -1,2 +1,2 @@
-ent-WindowTintedDirectional = направленное тонированное окно
+ent-WindowTintedDirectional = одностороннее зеркальное окно
     .desc = Смотри не заляпай.

--- a/Resources/Prototypes/_CorvaxNext/Entities/Structures/Windows/tinted.yml
+++ b/Resources/Prototypes/_CorvaxNext/Entities/Structures/Windows/tinted.yml
@@ -1,0 +1,73 @@
+- type: entity
+  id: WindowTintedDirectional
+  parent: WindowDirectionalRCDResistant
+  name: directional tinted window
+  description: Don't smudge up the glass down there.
+  placement:
+    mode: SnapgridCenter
+    snap:
+    - Window
+  components:
+  - type: Sprite
+    sprite: Structures/Windows/directional.rsi
+    state: frosted_window
+  - type: Icon
+    sprite: Structures/Windows/directional.rsi
+    state: frosted_window
+  - type: RCDDeconstructable
+    cost: 4
+    delay: 4
+    fx: EffectRCDDeconstruct4
+  - type: Occluder
+    boundingBox: "-0.5, -0.5, 0.5, -0.3"
+  - type: TintedWindow
+    arc: 170
+  - type: Damageable
+    damageModifierSet: RGlass
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.5,-0.5,0.5,-0.28125"
+        density: 1500
+        mask:
+        - FullTileMask
+        layer:
+        - GlassLayer
+        - Opaque
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: WindowShatter
+    - trigger:
+        !type:DamageTrigger
+        damage: 37
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: WindowShatter
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          ShardGlassReinforced:
+            min: 1
+            max: 2
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: Appearance
+  - type: DamageVisuals
+    thresholds: [5, 10, 20]
+    damageDivisor: 1.5
+    trackAllDamage: true
+    damageOverlay:
+      sprite: Structures/Windows/cracks_directional.rsi
+  - type: Penetratable # Corvax-Next - Better snipers
+    penetrateDamage: 25
+    damagePenalty: 0.1


### PR DESCRIPTION
## Описание PR
В игру добавлены односторонние окна. Доступны пока только через маппинг в связи с костыльной реализации (см.ниже). Лазеры через себя не пропускает.

## Почему / Баланс
Нужная штука в каких-нибудь допросках при маппинге. Как крафт пока не планирую включать

## Технические детали
Это грёбанное проклятие, а не код. Чтобы изменять `OccluderComponent` так, чтобы это выглядило красиво - нужно лезть в движок. Пришлось костылить, взяв код с направленных объектов (понимал бы я ещё как работает подобные вычисления в них) и просто поставил вкл и выкл оклюдера. Если ставить вдоль стен, то вообще не ощущается вырванной картинки.

## Медиа

https://github.com/user-attachments/assets/c80efa92-f3c5-421c-84e6-360c5d54d863


