### PR TITLE
Фикс пересадки печени (да и других органов тож в теории)

### DIFF
--- a/Content.Shared/_CorvaxNext/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_CorvaxNext/Surgery/SharedSurgerySystem.Steps.cs
@@ -442,12 +442,16 @@ public abstract partial class SharedSurgerySystem
         foreach (var tool in args.Tools)
         {
             if (HasComp(tool, firstOrgan.Component.GetType())
-                && TryComp<OrganComponent>(tool, out var insertedOrgan)
-                && _body.InsertOrgan(args.Part, tool, insertedOrgan.SlotId, partComp, insertedOrgan))
+                && TryComp<OrganComponent>(tool, out var insertedOrgan))
             {
+                // запоминаем Id тушки органа, т.к insertedOrgan.originalBody после InsertOrgan поменяется на новую тушку, тогда проверка не пройдет, и не будет эффекта
+                var originalBody = insertedOrgan.OriginalBody; // corvax-next
+                if (!_body.InsertOrgan(args.Part, tool, insertedOrgan.SlotId, partComp, insertedOrgan))
+                    return;
+
                 EnsureComp<OrganReattachedComponent>(tool);
                 if (_body.TrySetOrganUsed(tool, true, insertedOrgan)
-                    && insertedOrgan.OriginalBody != args.Body)
+                    && originalBody != args.Body)
                 {
                     var ev = new SurgeryStepDamageChangeEvent(args.User, args.Body, args.Part, ent);
                     RaiseLocalEvent(ent, ref ev);


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Добавил сохранения `originalBody` органа в локальную переменную перед вызовом `InsertOrgan`.

## Почему / Баланс
Так как `InsertOrgan` меняет `originalBody` органа на body нового тела, что делает проверку `insertedOrgan.OriginalBody != args.Body` невыполнимой ни при каких условиях (sick!). Моя PR'ка фиксит это.

Насрано было тут: https://github.com/space-syndicate/space-station-14-next/blob/7915b9f2fffeb7c6867a7555f8e3c35688fdf6bd/Content.Shared/Body/Systems/SharedBodySystem.Organs.cs#L43-L44
В этом коммите: https://github.com/space-syndicate/space-station-14-next/commit/598bc1cc18600757164dfec1f311cbe860723974

## Ссылка на ветку
<!-- Необязательный пункт. Удалите раздел целиком, если он пуст.
Ссылка на ветку обсуждения ПРа в Discord.
Следите, чтобы информация в первом сообщении была актуальной. -->

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
Сохраняю оригинальное значение originalBody в OnAddOrganStep и провожу проверку относительно него, а не с его всратым значением из-за сломанного апстрима год назад (sick!)

## Медиа
[video.webm](https://github.com/user-attachments/assets/6a973081-b3e7-4b22-b467-28030c44b0b6)
Что теперь происходит при пересадке печени

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
<!--
:cl:
- add: Добавлено веселье!
- remove: Удалено веселье!
- tweak: Изменено веселье!
- fix: Исправлено веселье!
-->
:cl:
- fix: исправил хирургию органов